### PR TITLE
Implement parsing tuples

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -37,20 +37,22 @@ pub struct FieldDecorator {
     pub arguments: Vec<Primitive>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Type {
     String,
     Number,
+    Tuple(Vec<Type>),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ParameterType {
     String,
     Number,
+    Tuple(Vec<Type>),
     Record,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Parameter {
     pub name: String,
     pub type_: ParameterType,
@@ -100,6 +102,7 @@ pub enum Expression {
     Primitive(Primitive),
     Ident(String),
     Boolean(bool),
+    Tuple(Vec<Expression>),
     Assign(Box<Expression>, Box<Expression>),
     AssignSub(Box<Expression>, Box<Expression>),
     AssignAdd(Box<Expression>, Box<Expression>),
@@ -127,6 +130,7 @@ pub enum Expression {
     Negate(Box<Expression>),
     Dot(Box<Expression>, String),
     Index(Box<Expression>, Box<Expression>),
+    IndexTuple(Box<Expression>, u8),
     Call(Box<Expression>, Vec<Expression>),
 }
 

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -13,11 +13,24 @@ Ident: String = {
 Type: Type = {
     "string" => Type::String,
     "number" => Type::Number,
+    <t:TupleType> => t,
+};
+
+TupleType: Type = {
+    "(" <t:Type> <ts:("," Type)+> ")" => {
+        let mut v = vec![t];
+        v.extend(ts.into_iter().map(|(_, t)| t));
+        Type::Tuple(v)
+    },
+    "(" <t:Type> ")" => Type::Tuple(vec![t]),
 };
 
 ParameterType: ParameterType = {
-    "string" => ParameterType::String,
-    "number" => ParameterType::Number,
+    <t:Type> => match t {
+        Type::String => ParameterType::String,
+        Type::Number => ParameterType::Number,
+        Type::Tuple(v) => ParameterType::Tuple(v),
+    },
     "record" => ParameterType::Record,
 };
 
@@ -58,9 +71,13 @@ pub Expression: Expression = {
     #[precedence(level="1")]
     <l:Expression> "." <id:Ident> => Expression::Dot(Box::new(l), id),
     #[precedence(level="1")]
+    <l:Expression> "." <n:Number> => Expression::IndexTuple(Box::new(l), n as u8),
+    #[precedence(level="1")]
     <l:Expression> "(" <args:ArgumentList> ")" => Expression::Call(Box::new(l), args),
     #[precedence(level="1")]
     "(" <e:Expression> ")" => e,
+    #[precedence(level="1")]
+    <t:Tuple> => Expression::Tuple(t),
     #[precedence(level="2")]
     <l:Expression> "!" => Expression::Not(Box::new(l)),
     #[precedence(level="2")]
@@ -109,6 +126,15 @@ pub Expression: Expression = {
     <l:Expression> "+=" <r:Expression> => Expression::AssignAdd(Box::new(l), Box::new(r)),
     #[precedence(level="14")] #[assoc(side="none")]
     <l:Expression> "=" <r:Expression> => Expression::Assign(Box::new(l), Box::new(r)),
+};
+
+Tuple: Vec<Expression> = {
+    "(" <el:Expression> <els:("," Expression)+> ")" => {
+        let mut v = vec![el];
+        v.extend(els.into_iter().map(|(_, e)| e));
+        v
+    },
+    "(" <el:Expression> "," ")" => vec![el],
 };
 
 ArgumentList: Vec<Expression> = {

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -4,18 +4,18 @@ use lalrpop_util::ParseError;
 
 grammar;
 
-pub Ident: String = {
+Ident: String = {
     <s:r"[a-zA-Z_\$][a-zA-Z0-9_]*"> => s.to_string(),
     "desc" => "desc".to_string(),
     "asc" => "asc".to_string(),
 };
 
-pub Type: Type = {
+Type: Type = {
     "string" => Type::String,
     "number" => Type::Number,
 };
 
-pub ParameterType: ParameterType = {
+ParameterType: ParameterType = {
     "string" => ParameterType::String,
     "number" => ParameterType::Number,
     "record" => ParameterType::Record,
@@ -31,16 +31,16 @@ pub String: String = {
     <s:r#"'[^']*'"#> => s[1..s.len()-1].to_string(),
 };
 
-pub Boolean: bool = {
+Boolean: bool = {
     "true" => true,
     "false" => false,
 };
 
-pub Regex: String = {
+Regex: String = {
     <s:r#"/[^/]*/"#> => s[1..s.len()-1].to_string(),
 };
 
-pub Primitive: Primitive = {
+Primitive: Primitive = {
     <n:Number> => Primitive::Number(n),
     <s:String> => Primitive::String(s),
     <r:Regex> => Primitive::Regex(r),
@@ -111,7 +111,7 @@ pub Expression: Expression = {
     <l:Expression> "=" <r:Expression> => Expression::Assign(Box::new(l), Box::new(r)),
 };
 
-pub ArgumentList: Vec<Expression> = {
+ArgumentList: Vec<Expression> = {
     <e:Expression> <rest:("," Expression)*> => {
         let mut args = vec![e];
         for (_, e) in rest {
@@ -122,7 +122,7 @@ pub ArgumentList: Vec<Expression> = {
     => vec![],
 };
 
-pub PrimitiveArgumentList: Vec<Primitive> = {
+PrimitiveArgumentList: Vec<Primitive> = {
     <p:Primitive> <rest:("," Primitive)*> => {
         let mut args = vec![p];
         for (_, p) in rest {
@@ -133,12 +133,12 @@ pub PrimitiveArgumentList: Vec<Primitive> = {
     => vec![],
 };
 
-pub CompoundStatement: Statement = {
+CompoundStatement: Statement = {
     <i:If> => Statement::If(i),
     <w:While> => Statement::While(w),
 }
 
-pub SmallStatement: Statement = {
+SmallStatement: Statement = {
     "break" => Statement::Break,
     "return" <e:Expression> => Statement::Return(e),
     "throw" <e:Expression> => Statement::Throw(e),
@@ -146,16 +146,16 @@ pub SmallStatement: Statement = {
     <e:Expression> => Statement::Expression(e),
 };
 
-pub SimpleStatement: Statement = {
+SimpleStatement: Statement = {
     <s:SmallStatement> ";" => s,
 };
 
-pub Statement: Statement = {
+Statement: Statement = {
     SimpleStatement,
     CompoundStatement,
 };
 
-pub StatementsOrSimpleStatement: Vec<Statement> = {
+StatementsOrSimpleStatement: Vec<Statement> = {
     "{" <s:Statement*> "}" => s,
     <s:SimpleStatement> => vec![s],
 };
@@ -168,14 +168,14 @@ pub If: If = {
     },
 };
 
-pub While: While = {
+While: While = {
     "while" "(" <e:Expression> ")" "{" <s:Statement*> "}" => While {
         condition: e,
         statements: s,
     },
 };
 
-pub ParameterList: Vec<Parameter> = {
+ParameterList: Vec<Parameter> = {
     <p:Parameter> <rest:("," Parameter)*> => {
         let mut params = vec![p];
         for (_, p) in rest {
@@ -186,7 +186,7 @@ pub ParameterList: Vec<Parameter> = {
     => vec![],
 };
 
-pub Parameter: Parameter = {
+Parameter: Parameter = {
     <name:Ident> ":" <type_:ParameterType> => Parameter {
         name,
         type_,
@@ -199,7 +199,7 @@ pub Parameter: Parameter = {
     },
 };
 
-pub RootFunction: Function = {
+RootFunction: Function = {
     "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
@@ -226,7 +226,7 @@ pub Function: Function = {
     },
 };
 
-pub Field: Field = {
+Field: Field = {
     <name:Ident> "?" ":" <type_:Type> => Field{
         name,
         type_,
@@ -239,7 +239,7 @@ pub Field: Field = {
     },
 };
 
-pub IndexField: IndexField = {
+IndexField: IndexField = {
     "[" <name:Ident> "," <order:Order> "]" => IndexField{
         name,
         order,
@@ -250,12 +250,12 @@ pub IndexField: IndexField = {
     },
 };
 
-pub Order: Order = {
+Order: Order = {
     "asc" => Order::Asc,
     "desc" => Order::Desc,
 };
 
-pub Index: Index = {
+Index: Index = {
     "@index" "(" <fields:IndexFields> ")"  => Index{
         unique: false,
         fields: fields,
@@ -266,7 +266,7 @@ pub Index: Index = {
     },
 };
 
-pub IndexFields: Vec<IndexField> = {
+IndexFields: Vec<IndexField> = {
     <f:IndexField> <rest:("," IndexField)*> => {
         let mut fields = vec![f];
         for (_, f) in rest {
@@ -277,7 +277,7 @@ pub IndexFields: Vec<IndexField> = {
     => vec![],
 };
 
-pub CollectionItem: CollectionItem = {
+CollectionItem: CollectionItem = {
     <f:Field> ";" => CollectionItem::Field(f),
     <i:Index> ";" => CollectionItem::Index(i),
     <f:Function> => CollectionItem::Function(f),
@@ -290,7 +290,7 @@ pub Collection: Collection = {
     },
 };
 
-pub RootNode: RootNode = {
+RootNode: RootNode = {
     <c:Collection> => RootNode::Collection(c),
     <f:RootFunction> => RootNode::Function(f),
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,10 @@ fn validate_set_out_json(collection_ast_json: &str, data_json: &str) -> String {
 }
 
 fn generate_collection_function(collection_ast: &str) -> Result<js::JSCollection, Error> {
-    let collection_ast: ast::Collection = serde_json::from_str(collection_ast).map_err(|e| Error {
-        message: e.to_string(),
-    })?;
+    let collection_ast: ast::Collection =
+        serde_json::from_str(collection_ast).map_err(|e| Error {
+            message: e.to_string(),
+        })?;
 
     Ok(js::generate_js_collection(&collection_ast))
 }
@@ -236,7 +237,7 @@ mod tests {
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code }) if name == "get_age" && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;")
+            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code, return_type: _ }) if name == "get_age" && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;")
         );
 
         let function = match &collection.items[0] {


### PR DESCRIPTION
Enables the following:
```javascript
function f(singleTuple: (number), multipleTuple: (number, string, number)): (number, string, number) {}

let singleTuple = (1,); // trailing comma needed to discern from parenthesized expressions. Same as in Rust and Python.
let multipleTuple = (1, 'test', 2);
let x = multipleTuple.1;
assert(x == 'test', '...');

collection Account {
  name: (string, string);
}
```