### PR TITLE
Implement parsing `for` statements

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -152,10 +152,16 @@ pub struct While {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct For {
-    pub initial_statement: Let,
+    pub initial_statement: ForInitialStatement,
     pub condition: Expression,
     pub post_statement: Expression,
     pub statements: Vec<Statement>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ForInitialStatement {
+    Let(Let),
+    Expression(Expression),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -89,10 +89,11 @@ pub enum Statement {
     Break,
     If(If),
     While(While),
+    For(For),
     Return(Expression),
     Expression(Expression),
     Throw(Expression),
-    Let(String, Expression),
+    Let(Let),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -131,6 +132,12 @@ pub enum Expression {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct Let {
+    pub identifier: String,
+    pub expression: Expression,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct If {
     pub condition: Expression,
     pub then_statements: Vec<Statement>,
@@ -140,6 +147,14 @@ pub struct If {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct While {
     pub condition: Expression,
+    pub statements: Vec<Statement>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct For {
+    pub initial_statement: Let,
+    pub condition: Expression,
+    pub post_statement: Expression,
     pub statements: Vec<Statement>,
 }
 

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -182,7 +182,13 @@ pub While: While = {
 
 pub For: For = {
     "for" "(" <init:Let> ";" <cond:Expression> ";" <post:Expression> ")" "{" <statements:Statement*> "}" => For {
-        initial_statement: init,
+        initial_statement: ForInitialStatement::Let(init),
+        condition: cond,
+        post_statement: post,
+        statements,
+    },
+    "for" "(" <init:Expression> ";" <cond:Expression> ";" <post:Expression> ")" "{" <statements:Statement*> "}" => For {
+        initial_statement: ForInitialStatement::Expression(init),
         condition: cond,
         post_statement: post,
         statements,

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -136,13 +136,18 @@ pub PrimitiveArgumentList: Vec<Primitive> = {
 pub CompoundStatement: Statement = {
     <i:If> => Statement::If(i),
     <w:While> => Statement::While(w),
-}
+    <f:For> => Statement::For(f),
+};
+
+Let: Let = {
+    "let" <i:Ident> "=" <e:Expression> => Let { identifier: i, expression: e },
+};
 
 pub SmallStatement: Statement = {
     "break" => Statement::Break,
     "return" <e:Expression> => Statement::Return(e),
     "throw" <e:Expression> => Statement::Throw(e),
-    "let" <i:Ident> "=" <e:Expression> => Statement::Let(i, e),
+    <l:Let> => Statement::Let(l),
     <e:Expression> => Statement::Expression(e),
 };
 
@@ -172,6 +177,15 @@ pub While: While = {
     "while" "(" <e:Expression> ")" "{" <s:Statement*> "}" => While {
         condition: e,
         statements: s,
+    },
+};
+
+pub For: For = {
+    "for" "(" <init:Let> ";" <cond:Expression> ";" <post:Expression> ")" "{" <statements:Statement*> "}" => For {
+        initial_statement: init,
+        condition: cond,
+        post_statement: post,
+        statements,
     },
 };
 


### PR DESCRIPTION
`for (let <identifier> = <expr>; <expr>; <expr>) { <statements> }`

I limited the initial statement to `let`, which I think is the most useful one, we can add support for other statements later.