### PR TITLE
Add array and map types

### DIFF
--- a/go/ast/ast.go
+++ b/go/ast/ast.go
@@ -51,6 +51,7 @@ type FieldDecorator struct {
 type Function struct {
 	Name           string        `json:"name"`
 	Parameters     []Parameter   `json:"parameters"`
+	ReturnType     *Type         `json:"return_type"`
 	Statements     []interface{} `json:"statements"`
 	StatementsCode string        `json:"statements_code"`
 }

--- a/go/ast/ast.go
+++ b/go/ast/ast.go
@@ -26,12 +26,22 @@ type Field struct {
 	Required bool   `json:"required"`
 }
 
-type Type string
+type Type struct {
+	Tag     string      `json:"tag"`
+	Content interface{} `json:"content,omitempty"`
+}
 
-const (
-	String Type = "String"
-	Number Type = "Number"
-)
+func (t *Type) IsString() bool {
+	return t.Tag == "String"
+}
+
+func (t *Type) IsNumber() bool {
+	return t.Tag == "Number"
+}
+
+func (t *Type) IsArray() bool {
+	return t.Tag == "Array"
+}
 
 type FieldDecorator struct {
 	Name      string      `json:"name"`
@@ -45,13 +55,30 @@ type Function struct {
 	StatementsCode string        `json:"statements_code"`
 }
 
-type FunctionType string
+type FunctionType struct {
+	Tag     string      `json:"tag"`
+	Content interface{} `json:"content,omitempty"`
+}
 
-const (
-	FunctionTypeString FunctionType = "String"
-	FunctionTypeNumber FunctionType = "Number"
-	FunctionTypeRecord FunctionType = "Record"
-)
+func (ft *FunctionType) IsString() bool {
+	return ft.Tag == "String"
+}
+
+func (ft *FunctionType) IsNumber() bool {
+	return ft.Tag == "Number"
+}
+
+func (ft *FunctionType) IsRecord() bool {
+	return ft.Tag == "Record"
+}
+
+func (ft *FunctionType) IsArray() bool {
+	return ft.Tag == "Array"
+}
+
+func (ft *FunctionType) IsMap() bool {
+	return ft.Tag == "Map"
+}
 
 type Parameter struct {
 	Name     string       `json:"name"`

--- a/go/ast/ast.go
+++ b/go/ast/ast.go
@@ -51,7 +51,6 @@ type FieldDecorator struct {
 type Function struct {
 	Name           string        `json:"name"`
 	Parameters     []Parameter   `json:"parameters"`
-	ReturnType     *Type         `json:"return_type"`
 	Statements     []interface{} `json:"statements"`
 	StatementsCode string        `json:"statements_code"`
 }

--- a/go/ast/ast.go
+++ b/go/ast/ast.go
@@ -43,6 +43,10 @@ func (t *Type) IsArray() bool {
 	return t.Tag == "Array"
 }
 
+func (t *Type) IsMap() bool {
+	return t.Tag == "Map"
+}
+
 type FieldDecorator struct {
 	Name      string      `json:"name"`
 	Arguments []Primitive `json:"arguments"`

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -37,16 +37,18 @@ pub struct FieldDecorator {
     pub arguments: Vec<Primitive>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Type {
     String,
     Number,
+    Array(Box<Type>),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ParameterType {
     String,
     Number,
+    Array(Type),
     Record,
 }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -67,6 +67,7 @@ pub struct Parameter {
 pub struct Function {
     pub name: String,
     pub parameters: Vec<Parameter>,
+    pub return_type: Option<Type>,
     pub statements: Vec<Statement>,
     pub statements_code: String,
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -67,7 +67,6 @@ pub struct Parameter {
 pub struct Function {
     pub name: String,
     pub parameters: Vec<Parameter>,
-    pub return_type: Option<Type>,
     pub statements: Vec<Statement>,
     pub statements_code: String,
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -38,17 +38,21 @@ pub struct FieldDecorator {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "tag", content = "content")]
 pub enum Type {
     String,
     Number,
     Array(Box<Type>),
+    Map(Box<Type>, Box<Type>),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "tag", content = "content")]
 pub enum ParameterType {
     String,
     Number,
     Array(Type),
+    Map(Type, Type),
     Record,
 }
 

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -210,27 +210,24 @@ pub Parameter: Parameter = {
 };
 
 pub RootFunction: Function = {
-    "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
+    "function" <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
-        return_type: return_type.map(|(_, t)| t),
         statements: s,
         statements_code: input[l..r].to_string(),
     }
 };
 
 pub Function: Function = {
-    "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
+    "function" <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
-        return_type: return_type.map(|(_, t)| t),
         statements: s,
         statements_code: input[l..r].to_string(),
     },
-    <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
+    <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
-        return_type: return_type.map(|(_, t)| t),
         statements: s,
         statements_code: input[l..r].to_string(),
     },

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -18,7 +18,7 @@ StringOrNumberType: Type = {
 Type: Type = {
     StringOrNumberType,
     <t:StringOrNumberType> "[" "]" => Type::Array(Box::new(t)),
-    "map" "<" <kt:StringOrNumberType> "," <vt:StringOrNumberType> ">" => Type::Map(Box::new(kt), Box::new(vt)),
+    "map" "<" <kt:StringOrNumberType> "," <vt:Type> ">" => Type::Map(Box::new(kt), Box::new(vt)),
 };
 
 ParameterType: ParameterType = {
@@ -88,19 +88,21 @@ pub Expression: Expression = {
     #[precedence(level="5")] #[assoc(side="left")]
     <l:Expression> "-" <r:Expression> => Expression::Subtract(Box::new(l), Box::new(r)),
     #[precedence(level="6")] #[assoc(side="left")]
-    <l:Expression> "<<" <r:Expression> => Expression::ShiftLeft(Box::new(l), Box::new(r)),
+    <l:Expression> "<" <second:("<")?> <r:Expression> => match second {
+        None => Expression::LessThan(Box::new(l), Box::new(r)),
+        Some(_) => Expression::ShiftLeft(Box::new(l), Box::new(r)),
+    },
     #[precedence(level="6")] #[assoc(side="left")]
-    <l:Expression> ">>" <r:Expression> => Expression::ShiftRight(Box::new(l), Box::new(r)),
+    <l:Expression> ">" <second:(">")?> <r:Expression> => match second {
+        None => Expression::GreaterThan(Box::new(l), Box::new(r)),
+        Some(_) => Expression::ShiftRight(Box::new(l), Box::new(r)),
+    },
     #[precedence(level="7")] #[assoc(side="left")]
     <l:Expression> "&" <r:Expression> => Expression::BitAnd(Box::new(l), Box::new(r)),
     #[precedence(level="8")] #[assoc(side="left")]
     <l:Expression> "^" <r:Expression> => Expression::BitXor(Box::new(l), Box::new(r)),
     #[precedence(level="9")] #[assoc(side="left")]
     <l:Expression> "|" <r:Expression> => Expression::BitOr(Box::new(l), Box::new(r)),
-    #[precedence(level="10")] #[assoc(side="none")]
-    <l:Expression> "<" <r:Expression> => Expression::LessThan(Box::new(l), Box::new(r)),
-    #[precedence(level="10")] #[assoc(side="none")]
-    <l:Expression> ">" <r:Expression> => Expression::GreaterThan(Box::new(l), Box::new(r)),
     #[precedence(level="10")] #[assoc(side="none")]
     <l:Expression> "<=" <r:Expression> => Expression::LessThanOrEqual(Box::new(l), Box::new(r)),
     #[precedence(level="10")] #[assoc(side="none")]

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -10,11 +10,15 @@ pub Ident: String = {
     "asc" => "asc".to_string(),
 };
 
-pub Type: Type = {
+StringOrNumberType: Type = {
     "string" => Type::String,
     "number" => Type::Number,
-    "string" "[" "]" => Type::Array(Box::new(Type::String)),
-    "number" "[" "]" => Type::Array(Box::new(Type::Number)),
+};
+
+pub Type: Type = {
+    StringOrNumberType,
+    <t:StringOrNumberType> "[" "]" => Type::Array(Box::new(t)),
+    "map" "<" <kt:StringOrNumberType> "," <vt:StringOrNumberType> ">" => Type::Map(Box::new(kt), Box::new(vt)),
 };
 
 pub ParameterType: ParameterType = {
@@ -22,6 +26,7 @@ pub ParameterType: ParameterType = {
         Type::String => ParameterType::String,
         Type::Number => ParameterType::Number,
         Type::Array(t) => ParameterType::Array(*t),
+        Type::Map(kt, vt) => ParameterType::Map(*kt, *vt),
     },
     "record" => ParameterType::Record,
 };

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -13,11 +13,16 @@ pub Ident: String = {
 pub Type: Type = {
     "string" => Type::String,
     "number" => Type::Number,
+    "string" "[" "]" => Type::Array(Box::new(Type::String)),
+    "number" "[" "]" => Type::Array(Box::new(Type::Number)),
 };
 
 pub ParameterType: ParameterType = {
-    "string" => ParameterType::String,
-    "number" => ParameterType::Number,
+    <t:Type> => match t {
+        Type::String => ParameterType::String,
+        Type::Number => ParameterType::Number,
+        Type::Array(t) => ParameterType::Array(*t),
+    },
     "record" => ParameterType::Record,
 };
 

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -210,24 +210,27 @@ pub Parameter: Parameter = {
 };
 
 pub RootFunction: Function = {
-    "function" <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
+    "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
+        return_type: return_type.map(|(_, t)| t),
         statements: s,
         statements_code: input[l..r].to_string(),
     }
 };
 
 pub Function: Function = {
-    "function" <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
+    "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
+        return_type: return_type.map(|(_, t)| t),
         statements: s,
         statements_code: input[l..r].to_string(),
     },
-    <i: Ident> "(" <pl:ParameterList> ")" "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
+    <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
+        return_type: return_type.map(|(_, t)| t),
         statements: s,
         statements_code: input[l..r].to_string(),
     },

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -15,13 +15,13 @@ StringOrNumberType: Type = {
     "number" => Type::Number,
 };
 
-pub Type: Type = {
+Type: Type = {
     StringOrNumberType,
     <t:StringOrNumberType> "[" "]" => Type::Array(Box::new(t)),
     "map" "<" <kt:StringOrNumberType> "," <vt:StringOrNumberType> ">" => Type::Map(Box::new(kt), Box::new(vt)),
 };
 
-pub ParameterType: ParameterType = {
+ParameterType: ParameterType = {
     <t:Type> => match t {
         Type::String => ParameterType::String,
         Type::Number => ParameterType::Number,

--- a/src/js.rs
+++ b/src/js.rs
@@ -6,16 +6,18 @@ pub struct JSCollection {
     code: String,
 }
 
-pub fn generate_js_collection (collection_ast: &ast::Collection) -> JSCollection {
+pub fn generate_js_collection(collection_ast: &ast::Collection) -> JSCollection {
     let fns = collection_ast
         .items
         .iter()
-        .filter_map(|item| 
-            if let ast::CollectionItem::Function(f) = item { 
-                let JSFunc{ name, code } = generate_js_function(&f);
+        .filter_map(|item| {
+            if let ast::CollectionItem::Function(f) = item {
+                let JSFunc { name, code } = generate_js_function(&f);
                 Some(format!("instance.{} = {}", &name, &code))
-            } 
-            else { None })
+            } else {
+                None
+            }
+        })
         .collect::<Vec<String>>()
         .join(";");
 
@@ -50,33 +52,39 @@ fn generate_js_function(func_ast: &ast::Function) -> JSFunc {
         name: func_ast.name.clone(),
         code: format!(
             "function {} ({}) {{\n{}\n}}",
-            func_ast.name, 
-            parameters,
-            func_ast.statements_code,
+            func_ast.name, parameters, func_ast.statements_code,
         ),
     }
 }
-
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_generate_js_function () {
-        let func_ast = ast::Function{ 
-            name: "HelloWorld".to_string(), 
+    fn test_generate_js_function() {
+        let func_ast = ast::Function {
+            name: "HelloWorld".to_string(),
             parameters: vec![
-                ast::Parameter{ name: "a".to_string(), type_: ast::ParameterType::String, required: true },
-                ast::Parameter{ name: "b".to_string(), type_: ast::ParameterType::Number, required: false },
+                ast::Parameter {
+                    name: "a".to_string(),
+                    type_: ast::ParameterType::String,
+                    required: true,
+                },
+                ast::Parameter {
+                    name: "b".to_string(),
+                    type_: ast::ParameterType::Number,
+                    required: false,
+                },
             ],
+            return_type: Some(ast::Type::String),
             statements: vec![],
             statements_code: "return a".to_string(),
         };
 
         assert_eq!(
             generate_js_function(&func_ast),
-            JSFunc{
+            JSFunc {
                 name: "HelloWorld".to_string(),
                 code: "function HelloWorld (a, b) {\nreturn a\n}".to_string(),
             }
@@ -84,34 +92,52 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_collection_function () {
-        let collection_ast = ast::Collection{
+    fn test_generate_collection_function() {
+        let collection_ast = ast::Collection {
             name: "CollectionName".to_string(),
             items: vec![
-                ast::CollectionItem::Field(ast::Field{
+                ast::CollectionItem::Field(ast::Field {
                     name: "abc".to_string(),
                     type_: ast::Type::String,
                     required: true,
                 }),
-                ast::CollectionItem::Function(ast::Function{
+                ast::CollectionItem::Function(ast::Function {
                     name: "Hello".to_string(),
                     parameters: vec![
-                        ast::Parameter{ name: "a".to_string(), type_: ast::ParameterType::String, required: true },
-                        ast::Parameter{ name: "b".to_string(), type_: ast::ParameterType::Number, required: false },
+                        ast::Parameter {
+                            name: "a".to_string(),
+                            type_: ast::ParameterType::String,
+                            required: true,
+                        },
+                        ast::Parameter {
+                            name: "b".to_string(),
+                            type_: ast::ParameterType::Number,
+                            required: false,
+                        },
                     ],
+                    return_type: Some(ast::Type::String),
                     statements: vec![],
                     statements_code: "return a".to_string(),
                 }),
-                ast::CollectionItem::Function(ast::Function{
+                ast::CollectionItem::Function(ast::Function {
                     name: "World".to_string(),
                     parameters: vec![
-                        ast::Parameter{ name: "c".to_string(), type_: ast::ParameterType::String, required: true },
-                        ast::Parameter{ name: "d".to_string(), type_: ast::ParameterType::Number, required: false },
+                        ast::Parameter {
+                            name: "c".to_string(),
+                            type_: ast::ParameterType::String,
+                            required: true,
+                        },
+                        ast::Parameter {
+                            name: "d".to_string(),
+                            type_: ast::ParameterType::Number,
+                            required: false,
+                        },
                     ],
+                    return_type: Some(ast::Type::String),
                     statements: vec![],
                     statements_code: "return c".to_string(),
-                })
-            ]
+                }),
+            ],
         };
 
         assert_eq!(
@@ -126,5 +152,4 @@ mod tests {
             }
         )
     }
-
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -6,18 +6,16 @@ pub struct JSCollection {
     code: String,
 }
 
-pub fn generate_js_collection(collection_ast: &ast::Collection) -> JSCollection {
+pub fn generate_js_collection (collection_ast: &ast::Collection) -> JSCollection {
     let fns = collection_ast
         .items
         .iter()
-        .filter_map(|item| {
-            if let ast::CollectionItem::Function(f) = item {
-                let JSFunc { name, code } = generate_js_function(&f);
+        .filter_map(|item| 
+            if let ast::CollectionItem::Function(f) = item { 
+                let JSFunc{ name, code } = generate_js_function(&f);
                 Some(format!("instance.{} = {}", &name, &code))
-            } else {
-                None
-            }
-        })
+            } 
+            else { None })
         .collect::<Vec<String>>()
         .join(";");
 
@@ -52,39 +50,33 @@ fn generate_js_function(func_ast: &ast::Function) -> JSFunc {
         name: func_ast.name.clone(),
         code: format!(
             "function {} ({}) {{\n{}\n}}",
-            func_ast.name, parameters, func_ast.statements_code,
+            func_ast.name, 
+            parameters,
+            func_ast.statements_code,
         ),
     }
 }
+
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_generate_js_function() {
-        let func_ast = ast::Function {
-            name: "HelloWorld".to_string(),
+    fn test_generate_js_function () {
+        let func_ast = ast::Function{ 
+            name: "HelloWorld".to_string(), 
             parameters: vec![
-                ast::Parameter {
-                    name: "a".to_string(),
-                    type_: ast::ParameterType::String,
-                    required: true,
-                },
-                ast::Parameter {
-                    name: "b".to_string(),
-                    type_: ast::ParameterType::Number,
-                    required: false,
-                },
+                ast::Parameter{ name: "a".to_string(), type_: ast::ParameterType::String, required: true },
+                ast::Parameter{ name: "b".to_string(), type_: ast::ParameterType::Number, required: false },
             ],
-            return_type: Some(ast::Type::String),
             statements: vec![],
             statements_code: "return a".to_string(),
         };
 
         assert_eq!(
             generate_js_function(&func_ast),
-            JSFunc {
+            JSFunc{
                 name: "HelloWorld".to_string(),
                 code: "function HelloWorld (a, b) {\nreturn a\n}".to_string(),
             }
@@ -92,52 +84,34 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_collection_function() {
-        let collection_ast = ast::Collection {
+    fn test_generate_collection_function () {
+        let collection_ast = ast::Collection{
             name: "CollectionName".to_string(),
             items: vec![
-                ast::CollectionItem::Field(ast::Field {
+                ast::CollectionItem::Field(ast::Field{
                     name: "abc".to_string(),
                     type_: ast::Type::String,
                     required: true,
                 }),
-                ast::CollectionItem::Function(ast::Function {
+                ast::CollectionItem::Function(ast::Function{
                     name: "Hello".to_string(),
                     parameters: vec![
-                        ast::Parameter {
-                            name: "a".to_string(),
-                            type_: ast::ParameterType::String,
-                            required: true,
-                        },
-                        ast::Parameter {
-                            name: "b".to_string(),
-                            type_: ast::ParameterType::Number,
-                            required: false,
-                        },
+                        ast::Parameter{ name: "a".to_string(), type_: ast::ParameterType::String, required: true },
+                        ast::Parameter{ name: "b".to_string(), type_: ast::ParameterType::Number, required: false },
                     ],
-                    return_type: Some(ast::Type::String),
                     statements: vec![],
                     statements_code: "return a".to_string(),
                 }),
-                ast::CollectionItem::Function(ast::Function {
+                ast::CollectionItem::Function(ast::Function{
                     name: "World".to_string(),
                     parameters: vec![
-                        ast::Parameter {
-                            name: "c".to_string(),
-                            type_: ast::ParameterType::String,
-                            required: true,
-                        },
-                        ast::Parameter {
-                            name: "d".to_string(),
-                            type_: ast::ParameterType::Number,
-                            required: false,
-                        },
+                        ast::Parameter{ name: "c".to_string(), type_: ast::ParameterType::String, required: true },
+                        ast::Parameter{ name: "d".to_string(), type_: ast::ParameterType::Number, required: false },
                     ],
-                    return_type: Some(ast::Type::String),
                     statements: vec![],
                     statements_code: "return c".to_string(),
-                }),
-            ],
+                })
+            ]
         };
 
         assert_eq!(
@@ -152,4 +126,5 @@ mod tests {
             }
         )
     }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ mod tests {
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code, return_type }) if name == "get_age" && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;" && return_type == &None)
+            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code }) if name == "get_age" && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;")
         );
 
         let function = match &collection.items[0] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,14 +537,14 @@ function x() {
         eprintln!("{}", collection.as_ref().unwrap_err().message);
         assert_eq!(
             collection.unwrap_err().message,
-            r#"Error found at line 3, column 22: Unrecognized token "object". Expected one of: "number", "string"
+            r#"Error found at line 3, column 22: Unrecognized token "object". Expected one of: "map", "number", "string"
 name: object;
       ^^^^^^"#,
         );
     }
 
     #[test]
-    fn test_array_field() {
+    fn test_array_map_field() {
         let cases = [
             (
                 "collection test { numbers: number[]; }",
@@ -559,6 +559,22 @@ name: object;
                 vec![ast::Field {
                     name: "strings".to_string(),
                     type_: ast::Type::Array(Box::new(ast::Type::String)),
+                    required: true,
+                }],
+            ),
+            (
+                "collection test { numToStr: map<number, string>; }",
+                vec![ast::Field {
+                    name: "numToStr".to_string(),
+                    type_: ast::Type::Map(Box::new(ast::Type::Number), Box::new(ast::Type::String)),
+                    required: true,
+                }],
+            ),
+            (
+                "collection test { strToNum: map<string, number>; }",
+                vec![ast::Field {
+                    name: "strToNum".to_string(),
+                    type_: ast::Type::Map(Box::new(ast::Type::String), Box::new(ast::Type::Number)),
                     required: true,
                 }],
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ mod tests {
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code }) if name == "get_age" && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;")
+            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function { name, parameters, statements, statements_code, return_type }) if name == "get_age" && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;" && return_type == &None)
         );
 
         let function = match &collection.items[0] {


### PR DESCRIPTION
Allows the user to define fields of type array `string[]`, `number[]` and map `map<string | number, string | number>`