### PR TITLE
Split validateSet into a separate dist file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2021"
 [lib]
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+default = ["parser"]
+parser = []
+
 [dependencies]
 regex = { version = "1", default-features = false }
 wasm-bindgen = "0.2"

--- a/js/package.json
+++ b/js/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "files": [
     "pkg/*",
+    "pkg-thin/*",
     "dist/*"
   ],
   "scripts": {

--- a/js/src/common.ts
+++ b/js/src/common.ts
@@ -1,0 +1,14 @@
+export interface Result<T> {
+  Err: {
+    message: string
+  }
+  Ok: T
+}
+
+export function unwrap<T> (value: Result<T>): T {
+  if (value.Err) {
+    throw new Error(value.Err.message)
+  }
+
+  return value.Ok
+}

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,14 +1,9 @@
+import { unwrap } from './common'
+
 const parser = import('../pkg/index.js').then(p => p.default).then(p => {
   p.init()
   return p
 })
-
-export interface Result<T> {
-  Err: {
-    message: string
-  }
-  Ok: T
-}
 
 export interface Program {
   nodes: RootNode[]
@@ -22,20 +17,8 @@ export interface RootNode {
 export type Collection = any
 export type Function = any
 
-function unwrap<T> (value: Result<T>): T {
-  if (value.Err) {
-    throw new Error(value.Err.message)
-  }
-
-  return value.Ok
-}
-
 export async function parse (code: string): Promise<Program> {
   return unwrap(JSON.parse((await parser).parse(code)))
-}
-
-export async function validateSet (collection: Collection, data: { [k: string]: any }): Promise<void> {
-  return unwrap(JSON.parse((await parser).validate_set(JSON.stringify(collection), JSON.stringify(data))))
 }
 
 export interface JSCollection {

--- a/js/src/validator/index.ts
+++ b/js/src/validator/index.ts
@@ -1,0 +1,10 @@
+import { unwrap } from '../common'
+
+const parser = import('../../pkg-thin/index.js').then(p => p.default).then(p => {
+  p.init()
+  return p
+})
+
+export async function validateSet (collectionAST: any, data: { [k: string]: any }): Promise<void> {
+  return unwrap(JSON.parse((await parser).validate_set(JSON.stringify(collectionAST), JSON.stringify(data))))
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -3,9 +3,58 @@ const fs = require('fs')
 const nodeExternals = require('webpack-node-externals')
 const WasmPackPlugin = require('@wasm-tool/wasm-pack-plugin')
 
+const inlineWASM = (pkgDir) => ({
+  apply: (compiler) => {
+    compiler.hooks.beforeCompile.tap('InlineWASM', () => {
+      const wasm = fs.readFileSync(
+        path.resolve(__dirname, pkgDir + '/index_bg.wasm'),
+      )
+
+      const js = `
+        import * as index_bg from "./index_bg.js"
+
+        const base64 = "${Buffer.from(wasm).toString('base64')}"
+
+        function toUint8Array (s) {
+          return new Uint8Array(atob(s).split('').map(c => c.charCodeAt(0)))
+        }
+
+        const wasm = toUint8Array(base64)
+
+        const { instance } = await WebAssembly.instantiate(wasm, {
+          "./index_bg.js": index_bg,
+        })
+
+        export default instance.exports
+      `
+
+      fs.writeFileSync(path.resolve(__dirname, pkgDir + '/index_bg.wasm.js'), js)
+
+      const index = fs.readFileSync(
+        path.resolve(__dirname, pkgDir + '/index_bg.js'),
+      )
+
+      fs.writeFileSync(
+        path.resolve(__dirname, pkgDir + '/index_bg.js'),
+        index
+          .toString()
+          .replace(
+            'import * as wasm from \'./index_bg.wasm\'',
+            'import wasm from \'./index_bg.wasm.js\'',
+          ),
+      )
+
+      fs.unlinkSync(path.resolve(__dirname, pkgDir + '/index_bg.wasm'))
+    })
+  },
+})
+
 module.exports = {
   target: 'web',
-  entry: './src/index.ts',
+  entry: {
+    index: './src/index.ts',
+    'validator/index': './src/validator/index.ts',
+  },
   experiments: {
     topLevelAwait: true,
   },
@@ -31,55 +80,17 @@ module.exports = {
       crateDirectory: path.resolve(__dirname, '..'),
       outDir: path.resolve(__dirname, 'pkg'),
     }),
-    {
-      apply: (compiler) => {
-        compiler.hooks.beforeCompile.tap('InlineWASM', () => {
-          const wasm = fs.readFileSync(
-            path.resolve(__dirname, 'pkg/index_bg.wasm'),
-          )
-
-          const js = `
-            import * as index_bg from "./index_bg.js"
-
-            const base64 = "${Buffer.from(wasm).toString('base64')}"
-
-            function toUint8Array (s) {
-              return new Uint8Array(atob(s).split('').map(c => c.charCodeAt(0)))
-            }
-
-            const wasm = toUint8Array(base64)
-
-            const { instance } = await WebAssembly.instantiate(wasm, {
-              "./index_bg.js": index_bg,
-            })
-
-            export default instance.exports
-          `
-
-          fs.writeFileSync(path.resolve(__dirname, 'pkg/index_bg.wasm.js'), js)
-
-          const index = fs.readFileSync(
-            path.resolve(__dirname, 'pkg/index_bg.js'),
-          )
-
-          fs.writeFileSync(
-            path.resolve(__dirname, 'pkg/index_bg.js'),
-            index
-              .toString()
-              .replace(
-                'import * as wasm from \'./index_bg.wasm\'',
-                'import wasm from \'./index_bg.wasm.js\'',
-              ),
-          )
-
-          fs.unlinkSync(path.resolve(__dirname, 'pkg/index_bg.wasm'))
-        })
-      },
-    },
+    inlineWASM('pkg'),
+    new WasmPackPlugin({
+      crateDirectory: path.resolve(__dirname, '..'),
+      outDir: path.resolve(__dirname, 'pkg-thin'),
+      extraArgs: '-- --no-default-features',
+    }),
+    inlineWASM('pkg-thin'),
   ],
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'index.js',
+    filename: '[name].js',
     libraryTarget: 'commonjs2',
   },
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -16,6 +16,7 @@ pub extern "C" fn init() {
 }
 
 #[cfg(target_arch = "wasm32")]
+#[cfg(feature = "parser")]
 #[wasm_bindgen]
 pub fn parse(input: &str) -> String {
     crate::parse_out_json(input)
@@ -34,6 +35,7 @@ pub fn generate_js_collection(collection_ast_json: &str) -> String {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "parser")]
 #[no_mangle]
 pub extern "C" fn parse(input: *const c_char) -> *mut c_char {
     let input = unsafe { std::ffi::CStr::from_ptr(input) };


### PR DESCRIPTION
Instead of importing `@polybase/polylang` you can now import `@polybase/polylang/dist/validator`. Validator weighs only 0.25MB, while the main entrypoint (with parser) is 1.4MB. We could potentially shrink this further in the future