### PR TITLE
Allow comments in Polylang

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Pull testnet collections
+        continue-on-error: true
+        run: |
+          ./pull-collections.sh
       - name: Test the main crate
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,12 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Test the main crate
+        uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Test the parser
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path parser/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ cp target/release/libpolylang.a go/parser/
 cd go
 go run .
 ```
+
+## Test
+
+```bash
+cargo test && (cd parser && cargo test)
+```
+
+You can download and test that collections from the testnet still parse by running:
+
+```bash
+./pull-collections.sh && cargo test
+```

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1,0 +1,827 @@
+use std::f32::consts::E;
+
+pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Tok<'input> {
+    NumberLiteral(f64),
+    StringLiteral(&'input str),
+    Identifier(&'input str),
+    Desc,
+    Asc,
+    True,
+    False,
+    Number,
+    String,
+    Map,
+    Record,
+    Let,
+    Break,
+    Return,
+    Throw,
+    If,
+    Else,
+    While,
+    For,
+    Function,
+    Index,
+    Unique,
+    Collection,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    LParen,
+    RParen,
+    ArrowRight, // >
+    ArrowLeft,  // <
+    Equal,      // =
+    EqualEqual, // ==
+    BangEqual,  // !=
+    MinusEqual, // -=
+    PlusEqual,  // +=
+    Comma,
+    Colon,
+    Semicolon,
+    Dot,
+    Plus,
+    Minus,
+    Star,     // *
+    StarStar, // **
+    Slash,    // /
+    Percent,
+    Bang,
+    Question,
+    Tilde,
+    Ampersand,
+    AmpersandAmpersand,
+    At, // @
+    Caret,
+    Pipe,
+    PipePipe,
+    Lte,
+    Gte,
+}
+
+impl std::fmt::Display for Tok<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Tok::NumberLiteral(n) => write!(f, "{}", n),
+            Tok::StringLiteral(s) => write!(f, "{}", s),
+            Tok::Identifier(s) => write!(f, "{}", s),
+            Tok::Desc => write!(f, "desc"),
+            Tok::Asc => write!(f, "asc"),
+            Tok::True => write!(f, "true"),
+            Tok::False => write!(f, "false"),
+            Tok::Number => write!(f, "number"),
+            Tok::String => write!(f, "string"),
+            Tok::Map => write!(f, "map"),
+            Tok::Record => write!(f, "record"),
+            Tok::Let => write!(f, "let"),
+            Tok::Break => write!(f, "break"),
+            Tok::Return => write!(f, "return"),
+            Tok::Throw => write!(f, "throw"),
+            Tok::If => write!(f, "if"),
+            Tok::Else => write!(f, "else"),
+            Tok::While => write!(f, "while"),
+            Tok::For => write!(f, "for"),
+            Tok::Function => write!(f, "function"),
+            Tok::Index => write!(f, "index"),
+            Tok::Unique => write!(f, "unique"),
+            Tok::Collection => write!(f, "collection"),
+            Tok::LBrace => write!(f, "{{"),
+            Tok::RBrace => write!(f, "}}"),
+            Tok::LBracket => write!(f, "["),
+            Tok::RBracket => write!(f, "]"),
+            Tok::LParen => write!(f, "("),
+            Tok::RParen => write!(f, ")"),
+            Tok::ArrowRight => write!(f, ">"),
+            Tok::ArrowLeft => write!(f, "<"),
+            Tok::Equal => write!(f, "="),
+            Tok::EqualEqual => write!(f, "=="),
+            Tok::BangEqual => write!(f, "!="),
+            Tok::MinusEqual => write!(f, "-="),
+            Tok::PlusEqual => write!(f, "+="),
+            Tok::Comma => write!(f, ","),
+            Tok::Colon => write!(f, ":"),
+            Tok::Semicolon => write!(f, ";"),
+            Tok::Dot => write!(f, "."),
+            Tok::Plus => write!(f, "+"),
+            Tok::Minus => write!(f, "-"),
+            Tok::Star => write!(f, "*"),
+            Tok::StarStar => write!(f, "**"),
+            Tok::Slash => write!(f, "/"),
+            Tok::Percent => write!(f, "%"),
+            Tok::Bang => write!(f, "!"),
+            Tok::Question => write!(f, "?"),
+            Tok::Tilde => write!(f, "~"),
+            Tok::Ampersand => write!(f, "&"),
+            Tok::AmpersandAmpersand => write!(f, "&&"),
+            Tok::At => write!(f, "@"),
+            Tok::Caret => write!(f, "^"),
+            Tok::Pipe => write!(f, "|"),
+            Tok::PipePipe => write!(f, "||"),
+            Tok::Lte => write!(f, "<="),
+            Tok::Gte => write!(f, ">="),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LexicalError {
+    NumberParseError { start: usize, end: usize },
+    InvalidToken { start: usize, end: usize },
+    UnterminatedComment { start: usize, end: usize },
+    UnterminatedString { start: usize, end: usize },
+    UserError { start: usize, end: usize, message: String },
+}
+
+impl std::fmt::Display for LexicalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LexicalError::NumberParseError { start, end } => {
+                write!(f, "Failed to parse number at {}-{}", start, end)
+            }
+            LexicalError::InvalidToken { start, end } => {
+                write!(f, "Invalid token at {}-{}", start, end)
+            }
+            LexicalError::UnterminatedComment { start, end } => {
+                write!(f, "Unterminated comment at {}-{}", start, end)
+            }
+            LexicalError::UnterminatedString { start, end } => {
+                write!(f, "Unterminated string at {}-{}", start, end)
+            }
+            LexicalError::UserError { start, end, message } => {
+                write!(f, "Error at {}-{}: {}", start, end, message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for LexicalError {}
+
+const KEYWORDS: &[(Tok, &str)] = &[
+    (Tok::Desc, "desc"),
+    (Tok::Asc, "asc"),
+    (Tok::True, "true"),
+    (Tok::False, "false"),
+    (Tok::Number, "number"),
+    (Tok::String, "string"),
+    (Tok::Map, "map"),
+    (Tok::Record, "record"),
+    (Tok::Let, "let"),
+    (Tok::Break, "break"),
+    (Tok::Return, "return"),
+    (Tok::Throw, "throw"),
+    (Tok::If, "if"),
+    (Tok::Else, "else"),
+    (Tok::While, "while"),
+    (Tok::For, "for"),
+    (Tok::Function, "function"),
+    (Tok::Index, "index"),
+    (Tok::Unique, "unique"),
+    (Tok::Collection, "collection"),
+];
+
+pub struct Lexer<'input> {
+    input: &'input str,
+    position: usize,
+    errored: bool,
+}
+
+type LexerItem<'input> = Spanned<Tok<'input>, usize, LexicalError>;
+
+impl<'input> Lexer<'input> {
+    pub fn new(input: &'input str) -> Self {
+        Self {
+            input,
+            position: 0,
+            errored: false,
+        }
+    }
+
+    fn peek_char(&self) -> Option<(usize, char)> {
+        self.input[self.position..]
+            .char_indices()
+            .next()
+            .map(|(i, c)| (i + self.position, c))
+    }
+
+    fn peek_char_nth(&self, nth: usize) -> Option<(usize, char)> {
+        self.input[self.position..]
+            .char_indices()
+            .nth(nth)
+            .map(|(i, c)| (i + self.position, c))
+    }
+
+    fn next_char(&mut self) -> Option<(usize, char)> {
+        let next = self.peek_char();
+        if let Some((i, c)) = next {
+            self.position = i + c.len_utf8();
+        }
+        next
+    }
+
+    fn reset_if_none(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Option<LexerItem<'input>>,
+    ) -> Option<LexerItem<'input>> {
+        let start = self.position;
+        let item = f(self);
+        if item.is_none() {
+            self.position = start;
+        }
+        item
+    }
+
+    fn eat_whitespace(&mut self) -> bool {
+        match self.peek_char() {
+            Some((_, c)) if c.is_whitespace() => {}
+            _ => return false,
+        }
+
+        while let Some((_, c)) = self.peek_char() {
+            if !c.is_whitespace() {
+                break;
+            }
+            self.next_char();
+        }
+
+        true
+    }
+
+    /// Eats comments in the form of `// ...` or `/* ... */`
+    fn eat_comments(&mut self) -> Result<bool, LexicalError> {
+        let mut found = false;
+
+        if let Some((_, '/')) = self.peek_char() {
+            match self.peek_char_nth(1) {
+                Some((i, '/')) => {
+                    self.next_char();
+                    self.next_char();
+
+                    found = true;
+
+                    while let Some((_, c)) = self.peek_char() {
+                        if c == '\n' {
+                            break;
+                        }
+
+                        self.next_char();
+                    }
+                }
+                Some((i, '*')) => {
+                    self.next_char();
+                    self.next_char();
+
+                    found = true;
+
+                    let found_end = loop {
+                        if let Some((_, '*')) = self.peek_char() {
+                            if let Some((_, '/')) = self.peek_char_nth(1) {
+                                self.next_char();
+                                self.next_char();
+                                break true;
+                            }
+                        }
+
+                        if self.next_char().is_none() {
+                            break false;
+                        }
+                    };
+
+                    if !found_end {
+                        return Err(LexicalError::UnterminatedComment {
+                            start: i - 1, // start of `/*`
+                            end: self.position,
+                        });
+                    }
+                }
+                None | Some(_) => {}
+            }
+        }
+
+        Ok(found)
+    }
+
+    fn lex_keyword(&mut self) -> Option<LexerItem<'input>> {
+        let (start, c) = self.peek_char()?;
+        if !c.is_alphabetic() {
+            return None;
+        }
+
+        let mut end = start;
+        let mut keyword = String::new();
+        while let Some((i, c)) = self.peek_char() {
+            if !c.is_alphabetic() {
+                break;
+            }
+            end = i;
+            keyword.push(c);
+            self.next_char();
+        }
+
+        KEYWORDS
+            .iter()
+            .find(|(_, k)| k == &&keyword)
+            .map(|(tok, _)| Ok::<_, LexicalError>((start, tok.clone(), end + c.len_utf8())))
+    }
+
+    fn lex_number(&mut self) -> Option<LexerItem<'input>> {
+        let (start, c) = self.peek_char()?;
+        if !c.is_numeric() {
+            return None;
+        }
+
+        let mut end = start;
+        let mut number = String::new();
+        while let Some((i, c)) = self.peek_char() {
+            if !c.is_numeric() && c != '.' {
+                break;
+            }
+            end = i;
+            number.push(c);
+            self.next_char();
+        }
+
+        number
+            .parse::<f64>()
+            .map_err(|_| LexicalError::NumberParseError {
+                start,
+                end: end + c.len_utf8(),
+            })
+            .map(|n| Ok((start, Tok::NumberLiteral(n), end + c.len_utf8())))
+            .ok()
+    }
+
+    /// parses 'hello' as Tok::String("'hello'")
+    fn lex_string(&mut self) -> Option<LexerItem<'input>> {
+        let (start, c) = self.peek_char()?;
+        if c != '\'' {
+            return None;
+        }
+        self.next_char();
+
+        let mut end = start;
+        let mut string = String::new();
+        let terminated = loop {
+            let Some((i, c)) = self.peek_char() else {
+                break false;
+            };
+
+            if c == '\'' {
+                end = i;
+                self.next_char();
+                break true;
+            }
+
+            end = i;
+            string.push(c);
+            self.next_char();
+        };
+
+        if !terminated {
+            return Some(Err(LexicalError::UnterminatedString {
+                start,
+                end: self.position,
+            }));
+        }
+
+        Some(Ok((
+            start,
+            Tok::StringLiteral(&self.input[start..end + c.len_utf8()]),
+            end + c.len_utf8(),
+        )))
+    }
+
+    fn lex_identifier(&mut self) -> Option<LexerItem<'input>> {
+        let (start, c) = self.peek_char()?;
+        if !(c.is_ascii_alphabetic() || c == '_' || c == '$') {
+            return None;
+        }
+
+        self.next_char();
+
+        let mut end = start;
+        let mut identifier = String::new();
+        while let Some((i, c)) = self.peek_char() {
+            if !(c.is_ascii_alphanumeric() || c == '_') {
+                break;
+            }
+            end = i;
+            identifier.push(c);
+            self.next_char();
+        }
+
+        Some(Ok((
+            start,
+            Tok::Identifier(&self.input[start..end + c.len_utf8()]),
+            end + c.len_utf8(),
+        )))
+    }
+}
+
+impl<'input> Iterator for Lexer<'input> {
+    type Item = LexerItem<'input>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.errored {
+            return None;
+        }
+
+        loop {
+            let found_whitespace = self.eat_whitespace();
+            let found_comment = match self.eat_comments() {
+                Ok(b) => b,
+                Err(e) => {
+                    return Some(Err(e));
+                }
+            };
+
+            if !found_whitespace && !found_comment {
+                break;
+            }
+        }
+
+        let result = self
+            .reset_if_none(Self::lex_keyword)
+            .or_else(|| self.reset_if_none(Self::lex_number))
+            .or_else(|| self.reset_if_none(Self::lex_string))
+            .or_else(|| self.reset_if_none(Self::lex_identifier))
+            .or_else(|| match self.peek_char()? {
+                (i, '{') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::LBrace, i + 1)))
+                }
+                (i, '}') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::RBrace, i + 1)))
+                }
+                (i, '[') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::LBracket, i + 1)))
+                }
+                (i, ']') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::RBracket, i + 1)))
+                }
+                (i, '(') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::LParen, i + 1)))
+                }
+                (i, ')') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::RParen, i + 1)))
+                }
+                (i, '>') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '=')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::Gte, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::ArrowRight, i + 1))),
+                    }
+                }
+                (i, '<') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '=')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::Lte, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::ArrowLeft, i + 1))),
+                    }
+                }
+                (i, '=') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '=')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::EqualEqual, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Equal, i + 1))),
+                    }
+                }
+                (i, ',') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Comma, i + 1)))
+                }
+                (i, ';') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Semicolon, i + 1)))
+                }
+                (i, ':') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Colon, i + 1)))
+                }
+                (i, '.') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Dot, i + 1)))
+                }
+                (i, '+') => {
+                    self.next_char();
+
+                    match self.peek_char() {
+                        Some((_, '=')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::PlusEqual, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Plus, i + 1))),
+                    }
+                }
+                (i, '-') => {
+                    self.next_char();
+
+                    match self.peek_char() {
+                        Some((_, '=')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::MinusEqual, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Minus, i + 1))),
+                    }
+                }
+                (i, '/') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Slash, i + 1)))
+                }
+                (i, '%') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Percent, i + 1)))
+                }
+                (i, '!') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '=')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::BangEqual, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Bang, i + 1))),
+                    }
+                }
+                (i, '?') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Question, i + 1)))
+                }
+                (i, '~') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Tilde, i + 1)))
+                }
+                (i, '*') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '*')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::StarStar, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Star, i + 1))),
+                    }
+                }
+                (i, '&') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '&')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::AmpersandAmpersand, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Ampersand, i + 1))),
+                    }
+                }
+                (i, '@') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::At, i + 1)))
+                }
+                (i, '^') => {
+                    self.next_char();
+                    Some(Ok((i, Tok::Caret, i + 1)))
+                }
+                (i, '|') => {
+                    self.next_char();
+                    match self.peek_char() {
+                        Some((_, '|')) => {
+                            self.next_char();
+                            Some(Ok((i, Tok::PipePipe, i + 2)))
+                        }
+                        _ => Some(Ok((i, Tok::Pipe, i + 1))),
+                    }
+                }
+                _ => None,
+            })
+            .or_else(|| {
+                if let Some((i, c)) = self.peek_char() {
+                    self.next_char();
+                    Some(Err(LexicalError::InvalidToken { start: i, end: i }))
+                } else {
+                    None
+                }
+            });
+
+        if let Some(Err(_)) = result {
+            self.errored = true;
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lex_whitespace() {
+        let mut lexer = Lexer::new("  ");
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_whitespace_2() {
+        let mut lexer = Lexer::new("  asc");
+        assert_eq!(lexer.next(), Some(Ok((2, Tok::Asc, 5))));
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_keyword() {
+        let input = "desc asc";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), Some(Ok((0, Tok::Desc, 4))));
+        assert_eq!(&input[0..4], "desc");
+        assert_eq!(lexer.next(), Some(Ok((5, Tok::Asc, 8))));
+        assert_eq!(&input[5..8], "asc");
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_number() {
+        let mut lexer = Lexer::new("123.456 987");
+        assert_eq!(lexer.next(), Some(Ok((0, Tok::NumberLiteral(123.456), 7))));
+        assert_eq!(lexer.next(), Some(Ok((8, Tok::NumberLiteral(987.0), 11))));
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_number_error() {
+        let mut lexer = Lexer::new("123.456.789");
+        assert_eq!(
+            lexer.next(),
+            Some(Err(LexicalError::InvalidToken { start: 0, end: 0 }))
+        );
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_string() {
+        let input = "'hello' 'world'";
+        let mut lexer = Lexer::new("'hello' 'world'");
+        assert_eq!(
+            lexer.next(),
+            Some(Ok((0, Tok::StringLiteral("'hello'"), 7)))
+        );
+        assert_eq!(&input[0..7], "'hello'");
+        assert_eq!(
+            lexer.next(),
+            Some(Ok((8, Tok::StringLiteral("'world'"), 15)))
+        );
+        assert_eq!(&input[8..15], "'world'");
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_string_unterminated() {
+        let mut lexer = Lexer::new("'hello");
+        assert_eq!(
+            lexer.next(),
+            Some(Err(LexicalError::UnterminatedString { start: 0, end: 6 }))
+        );
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_identifier() {
+        let input = "hello world";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), Some(Ok((0, Tok::Identifier("hello"), 5))));
+        assert_eq!(&input[0..5], "hello");
+        assert_eq!(lexer.next(), Some(Ok((6, Tok::Identifier("world"), 11))));
+        assert_eq!(&input[6..11], "world");
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_identifier_dollar() {
+        let input = "$hello $world";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), Some(Ok((0, Tok::Identifier("$hello"), 6))));
+        assert_eq!(&input[0..6], "$hello");
+        assert_eq!(lexer.next(), Some(Ok((7, Tok::Identifier("$world"), 13))));
+        assert_eq!(&input[7..13], "$world");
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_identifier_unicode_invalid() {
+        let input = "ą";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(
+            lexer.next(),
+            Some(Err(LexicalError::InvalidToken { start: 0, end: 0 }))
+        );
+    }
+
+    #[test]
+    fn test_lex_symbols() {
+        let cases = [
+            ("(", Tok::LParen),
+            (")", Tok::RParen),
+            ("[", Tok::LBracket),
+            ("]", Tok::RBracket),
+            ("{", Tok::LBrace),
+            ("}", Tok::RBrace),
+            ("+", Tok::Plus),
+            ("-", Tok::Minus),
+            ("*", Tok::Star),
+            ("**", Tok::StarStar),
+            ("/", Tok::Slash),
+            ("%", Tok::Percent),
+            ("!", Tok::Bang),
+            ("?", Tok::Question),
+            ("~", Tok::Tilde),
+            ("&", Tok::Ampersand),
+            ("&&", Tok::AmpersandAmpersand),
+            ("@", Tok::At),
+            ("^", Tok::Caret),
+            ("|", Tok::Pipe),
+            ("||", Tok::PipePipe),
+            ("=", Tok::Equal),
+            ("==", Tok::EqualEqual),
+            ("!=", Tok::BangEqual),
+            ("-=", Tok::MinusEqual),
+            ("+=", Tok::PlusEqual),
+            (",", Tok::Comma),
+            (":", Tok::Colon),
+            (";", Tok::Semicolon),
+            (".", Tok::Dot),
+            ("<", Tok::ArrowLeft),
+            (">", Tok::ArrowRight),
+            ("<=", Tok::Lte),
+            (">=", Tok::Gte),
+        ];
+
+        for (input, expected) in cases.into_iter() {
+            let mut lexer = Lexer::new(input);
+            assert_eq!(lexer.next(), Some(Ok((0, expected, input.len()))));
+            assert_eq!(lexer.next(), None);
+        }
+    }
+
+    #[test]
+    fn test_comments() {
+        let input = "/* comment */";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_comments_2() {
+        let input = "/* comment */ 123";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), Some(Ok((14, Tok::NumberLiteral(123.0), 17))));
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_comments_single_line() {
+        let input = "// comment";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_comments_mixed() {
+        let input = r#"// comment
+            123
+            /* comment */
+            456
+            /*
+                multi-
+                line
+            */
+        "#;
+
+        let mut lexer = Lexer::new(input);
+        assert_eq!(lexer.next(), Some(Ok((23, Tok::NumberLiteral(123.0), 26))));
+        assert_eq!(lexer.next(), Some(Ok((65, Tok::NumberLiteral(456.0), 68))));
+        assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_comments_error() {
+        let input = "/* comment";
+        let mut lexer = Lexer::new(input);
+        assert_eq!(
+            lexer.next(),
+            Some(Err(LexicalError::UnterminatedComment { start: 0, end: 10 }))
+        );
+    }
+}

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,6 +1,22 @@
 pub mod ast;
+mod lexer;
 
 use lalrpop_util::lalrpop_mod;
 pub use lalrpop_util::ParseError;
+pub use lexer::LexicalError;
 
-lalrpop_mod!(pub polylang);
+lalrpop_mod!(polylang);
+
+pub fn parse(
+    input: &str,
+) -> Result<ast::Program, ParseError<usize, lexer::Tok, lexer::LexicalError>> {
+    let lexer = lexer::Lexer::new(input);
+    polylang::ProgramParser::new().parse(input, lexer)
+}
+
+pub fn parse_expression(
+    input: &str,
+) -> Result<ast::Expression, ParseError<usize, lexer::Tok, lexer::LexicalError>> {
+    let lexer = lexer::Lexer::new(input);
+    polylang::ExpressionParser::new().parse(input, lexer)
+}

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -74,6 +74,7 @@ pub Ident: String = {
     <i:identifier> => i.to_string(),
     "desc" => "desc".to_string(),
     "asc" => "asc".to_string(),
+    "index" => "index".to_string(),
 };
 
 StringOrNumberType: Type = {

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -70,7 +70,7 @@ extern {
     }
 }
 
-pub Ident: String = {
+Ident: String = {
     <i:identifier> => i.to_string(),
     "desc" => "desc".to_string(),
     "asc" => "asc".to_string(),
@@ -109,20 +109,20 @@ ParameterType: ParameterType = {
     },
 };
 
-pub Number: f64 = {
+Number: f64 = {
     <n:number> => n,
 };
 
-pub String: String = {
+String: String = {
     <s:string> => s[1..s.len()-1].to_string(),
 };
 
-pub Boolean: bool = {
+Boolean: bool = {
     "true" => true,
     "false" => false,
 };
 
-pub Primitive: Primitive = {
+Primitive: Primitive = {
     <n:Number> => Primitive::Number(n),
     <s:String> => Primitive::String(s),
 };
@@ -205,7 +205,7 @@ pub Expression: Expression = {
     <l:Expression> "=" <r:Expression> => Expression::Assign(Box::new(l), Box::new(r)),
 };
 
-pub ArgumentList: Vec<Expression> = {
+ArgumentList: Vec<Expression> = {
     <e:Expression> <rest:("," Expression)*> => {
         let mut args = vec![e];
         for (_, e) in rest {
@@ -216,7 +216,7 @@ pub ArgumentList: Vec<Expression> = {
     => vec![],
 };
 
-pub PrimitiveArgumentList: Vec<Primitive> = {
+PrimitiveArgumentList: Vec<Primitive> = {
     <p:Primitive> <rest:("," Primitive)*> => {
         let mut args = vec![p];
         for (_, p) in rest {
@@ -227,7 +227,7 @@ pub PrimitiveArgumentList: Vec<Primitive> = {
     => vec![],
 };
 
-pub CompoundStatement: Statement = {
+CompoundStatement: Statement = {
     <i:If> => Statement::If(i),
     <w:While> => Statement::While(w),
     <f:For> => Statement::For(f),
@@ -237,7 +237,7 @@ Let: Let = {
     "let" <i:Ident> "=" <e:Expression> => Let { identifier: i, expression: e },
 };
 
-pub SmallStatement: Statement = {
+SmallStatement: Statement = {
     "break" => Statement::Break,
     "return" <e:Expression> => Statement::Return(e),
     "throw" <e:Expression> => Statement::Throw(e),
@@ -245,21 +245,21 @@ pub SmallStatement: Statement = {
     <e:Expression> => Statement::Expression(e),
 };
 
-pub SimpleStatement: Statement = {
+SimpleStatement: Statement = {
     <s:SmallStatement> ";" => s,
 };
 
-pub Statement: Statement = {
+Statement: Statement = {
     SimpleStatement,
     CompoundStatement,
 };
 
-pub StatementsOrSimpleStatement: Vec<Statement> = {
+StatementsOrSimpleStatement: Vec<Statement> = {
     "{" <s:Statement*> "}" => s,
     <s:SimpleStatement> => vec![s],
 };
 
-pub If: If = {
+If: If = {
     "if" "(" <e:Expression> ")" <s:StatementsOrSimpleStatement> <s2:("else" StatementsOrSimpleStatement)?> => If {
         condition: e,
         then_statements: s,
@@ -267,14 +267,14 @@ pub If: If = {
     },
 };
 
-pub While: While = {
+While: While = {
     "while" "(" <e:Expression> ")" "{" <s:Statement*> "}" => While {
         condition: e,
         statements: s,
     },
 };
 
-pub For: For = {
+For: For = {
     "for" "(" <init:Let> ";" <cond:Expression> ";" <post:Expression> ")" "{" <statements:Statement*> "}" => For {
         initial_statement: ForInitialStatement::Let(init),
         condition: cond,
@@ -289,7 +289,7 @@ pub For: For = {
     },
 };
 
-pub ParameterList: Vec<Parameter> = {
+ParameterList: Vec<Parameter> = {
     <p:Parameter> <rest:("," Parameter)*> => {
         let mut params = vec![p];
         for (_, p) in rest {
@@ -300,7 +300,7 @@ pub ParameterList: Vec<Parameter> = {
     => vec![],
 };
 
-pub Parameter: Parameter = {
+Parameter: Parameter = {
     <name:Ident> ":" <type_:ParameterType> => Parameter {
         name,
         type_,
@@ -313,7 +313,7 @@ pub Parameter: Parameter = {
     },
 };
 
-pub RootFunction: Function = {
+RootFunction: Function = {
     "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
@@ -323,7 +323,7 @@ pub RootFunction: Function = {
     }
 };
 
-pub Function: Function = {
+Function: Function = {
     "function" <i: Ident> "(" <pl:ParameterList> ")" <return_type:(":" Type)?> "{" <l:@L> <s:Statement*> <r:@R> "}" => Function {
         name: i,
         parameters: pl,
@@ -340,7 +340,7 @@ pub Function: Function = {
     },
 };
 
-pub Field: Field = {
+Field: Field = {
     <name:Ident> "?" ":" <type_:Type> => Field{
         name,
         type_,
@@ -353,7 +353,7 @@ pub Field: Field = {
     },
 };
 
-pub IndexField: IndexField = {
+IndexField: IndexField = {
     "[" <name:Ident> "," <order:Order> "]" => IndexField{
         name,
         order,
@@ -364,12 +364,12 @@ pub IndexField: IndexField = {
     },
 };
 
-pub Order: Order = {
+Order: Order = {
     "asc" => Order::Asc,
     "desc" => Order::Desc,
 };
 
-pub Index: Index = {
+Index: Index = {
     "@" "index" "(" <fields:IndexFields> ")"  => Index{
         unique: false,
         fields: fields,
@@ -380,7 +380,7 @@ pub Index: Index = {
     },
 };
 
-pub IndexFields: Vec<IndexField> = {
+IndexFields: Vec<IndexField> = {
     <f:IndexField> <rest:("," IndexField)*> => {
         let mut fields = vec![f];
         for (_, f) in rest {
@@ -391,20 +391,20 @@ pub IndexFields: Vec<IndexField> = {
     => vec![],
 };
 
-pub CollectionItem: CollectionItem = {
+CollectionItem: CollectionItem = {
     <f:Field> ";" => CollectionItem::Field(f),
     <i:Index> ";" => CollectionItem::Index(i),
     <f:Function> => CollectionItem::Function(f),
 };
 
-pub Collection: Collection = {
+Collection: Collection = {
     "collection" <name:Ident> "{" <items:CollectionItem*> "}" => Collection {
         name: name,
         items: items,
     },
 };
 
-pub RootNode: RootNode = {
+RootNode: RootNode = {
     <c:Collection> => RootNode::Collection(c),
     <f:RootFunction> => RootNode::Function(f),
 };

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -1,11 +1,77 @@
 use crate::ast::*;
+use crate::lexer;
 use std::str::FromStr;
 use lalrpop_util::ParseError;
 
-grammar;
+grammar<'input>(input: &'input str);
+
+extern {
+    type Location = usize;
+    type Error = lexer::LexicalError;
+
+    enum lexer::Tok<'input> {
+        identifier => lexer::Tok::Identifier(<&'input str>),
+        number => lexer::Tok::NumberLiteral(<f64>),
+        string => lexer::Tok::StringLiteral(<&'input str>),
+        "desc" => lexer::Tok::Desc,
+        "asc" => lexer::Tok::Asc,
+        "true" => lexer::Tok::True,
+        "false" => lexer::Tok::False,
+        "string" => lexer::Tok::String,
+        "number" => lexer::Tok::Number,
+        "map" => lexer::Tok::Map,
+        "record" => lexer::Tok::Record,
+        "let" => lexer::Tok::Let,
+        "break" => lexer::Tok::Break,
+        "return" => lexer::Tok::Return,
+        "throw" => lexer::Tok::Throw,
+        "if" => lexer::Tok::If,
+        "else" => lexer::Tok::Else,
+        "while" => lexer::Tok::While,
+        "for" => lexer::Tok::For,
+        "function" => lexer::Tok::Function,
+        "index" => lexer::Tok::Index,
+        "unique" => lexer::Tok::Unique,
+        "collection" => lexer::Tok::Collection,
+        "{" => lexer::Tok::LBrace,
+        "}" => lexer::Tok::RBrace,
+        "[" => lexer::Tok::LBracket,
+        "]" => lexer::Tok::RBracket,
+        "(" => lexer::Tok::LParen,
+        ")" => lexer::Tok::RParen,
+        "<" => lexer::Tok::ArrowLeft,
+        ">" => lexer::Tok::ArrowRight,
+        ":" => lexer::Tok::Colon,
+        ";" => lexer::Tok::Semicolon,
+        "," => lexer::Tok::Comma,
+        "." => lexer::Tok::Dot,
+        "!" => lexer::Tok::Bang,
+        "?" => lexer::Tok::Question,
+        "~" => lexer::Tok::Tilde,
+        "*" => lexer::Tok::Star,
+        "/" => lexer::Tok::Slash,
+        "%" => lexer::Tok::Percent,
+        "+" => lexer::Tok::Plus,
+        "-" => lexer::Tok::Minus,
+        "&" => lexer::Tok::Ampersand,
+        "**" => lexer::Tok::StarStar,
+        "&&" => lexer::Tok::AmpersandAmpersand,
+        "@" => lexer::Tok::At,
+        "^" => lexer::Tok::Caret,
+        "|" => lexer::Tok::Pipe,
+        "||" => lexer::Tok::PipePipe,
+        "<=" => lexer::Tok::Lte,
+        ">=" => lexer::Tok::Gte,
+        "=" => lexer::Tok::Equal,
+        "==" => lexer::Tok::EqualEqual,
+        "!=" => lexer::Tok::BangEqual,
+        "-=" => lexer::Tok::MinusEqual,
+        "+=" => lexer::Tok::PlusEqual,
+    }
+}
 
 pub Ident: String = {
-    <s:r"[a-zA-Z_\$][a-zA-Z0-9_]*"> => s.to_string(),
+    <i:identifier> => i.to_string(),
     "desc" => "desc".to_string(),
     "asc" => "asc".to_string(),
 };
@@ -23,13 +89,17 @@ Type: Type = {
 };
 
 ParameterType: ParameterType = {
-    <t:Type> =>? match t {
+    <l:@L> <t:Type> =>? match t {
         Type::String => Ok(ParameterType::String),
         Type::Number => Ok(ParameterType::Number),
         Type::Array(t) => Ok(ParameterType::Array(*t)),
         Type::Map(kt, vt) => Ok(ParameterType::Map(*kt, *vt)),
         Type::Object(fields) => Err(ParseError::User {
-            error: "object type not allowed for parameter",
+            error: lexer::LexicalError::UserError {
+                start: l,
+                end: l,
+                message: "object type not allowed for parameter".to_string(),
+            }
         }),
     },
     "record" => ParameterType::Record,
@@ -39,13 +109,11 @@ ParameterType: ParameterType = {
 };
 
 pub Number: f64 = {
-    <s:r"-?[0-9]+(\.[0-9]+)?"> =>? f64::from_str(s).map_err(|_| ParseError::User {
-        error: "invalid number",
-    }),
+    <n:number> => n,
 };
 
 pub String: String = {
-    <s:r#"'[^']*'"#> => s[1..s.len()-1].to_string(),
+    <s:string> => s[1..s.len()-1].to_string(),
 };
 
 pub Boolean: bool = {
@@ -53,14 +121,9 @@ pub Boolean: bool = {
     "false" => false,
 };
 
-pub Regex: String = {
-    <s:r#"/[^/]*/"#> => s[1..s.len()-1].to_string(),
-};
-
 pub Primitive: Primitive = {
     <n:Number> => Primitive::Number(n),
     <s:String> => Primitive::String(s),
-    <r:Regex> => Primitive::Regex(r),
 };
 
 ObjectFieldValues: Vec<(String, Expression)> = {
@@ -90,9 +153,9 @@ pub Expression: Expression = {
     #[precedence(level="1")]
     "(" <e:Expression> ")" => e,
     #[precedence(level="2")]
-    <l:Expression> "!" => Expression::Not(Box::new(l)),
+    "!" <l:Expression> => Expression::Not(Box::new(l)),
     #[precedence(level="2")]
-    <l:Expression> "~" => Expression::BitNot(Box::new(l)),
+    "~" <l:Expression> => Expression::BitNot(Box::new(l)),
     #[precedence(level="3")] #[assoc(side="left")]
     <l:Expression> "**" <r:Expression> => Expression::Exponent(Box::new(l), Box::new(r)),
     #[precedence(level="4")] #[assoc(side="left")]
@@ -306,11 +369,11 @@ pub Order: Order = {
 };
 
 pub Index: Index = {
-    "@index" "(" <fields:IndexFields> ")"  => Index{
+    "@" "index" "(" <fields:IndexFields> ")"  => Index{
         unique: false,
         fields: fields,
     },
-    "@unique" "(" <fields:IndexFields> ")"  => Index{
+    "@" "unique" "(" <fields:IndexFields> ")"  => Index{
         unique: true,
         fields: fields,
     },

--- a/pull-collections.sh
+++ b/pull-collections.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p test-collections
+
+collections="$(curl -L 'https://testnet.polybase.xyz/v0/collections/Collection/documents' | jq -r '.data | .[].data | @base64')"
+
+for collection in $collections; do
+    collection="$(echo "$collection" | base64 -d)"
+    id="$(echo "$collection" | jq -r '.id')"
+    code="$(echo "$collection" | jq -r '.code')"
+
+    echo "$code" > "test-collections/$(sed -e 's/[]\/$*.^[]/-/g' <<< "$id")"
+done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod bindings;
 mod js;
 mod validation;
 
-use polylang_parser::{ast, polylang, ParseError};
+use polylang_parser::{ast, LexicalError, ParseError};
 use serde::Serialize;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
@@ -11,10 +11,9 @@ struct Error {
     message: String,
 }
 
-fn parse_error_to_error<T, E>(input: &str, error: ParseError<usize, T, E>) -> Error
+fn parse_error_to_error<T>(input: &str, error: ParseError<usize, T, LexicalError>) -> Error
 where
     T: std::fmt::Display + std::fmt::Debug,
-    E: std::fmt::Display + std::fmt::Debug,
 {
     let get_line_start = |start_byte| input[..start_byte].rfind('\n').map(|i| i + 1).unwrap_or(0);
     let get_line_end = |end_byte| {
@@ -72,16 +71,22 @@ where
         ParseError::ExtraToken {
             token: (start_byte, token, end_byte),
         } => make_err(start_byte, end_byte, &format!("Extra token \"{}\"", token)),
-        ParseError::User { error } => Error {
-            message: format!("{:?}", error),
+        ParseError::User { error } => match error {
+            LexicalError::NumberParseError { start, end } => make_err(start, end, "Failed to parse number"),
+            LexicalError::InvalidToken { start, end } => make_err(start, end, "Invalid token"),
+            LexicalError::UnterminatedComment { start, end } => {
+                make_err(start, end, "Unterminated comment")
+            }
+            LexicalError::UnterminatedString { start, end } => {
+                make_err(start, end, "Unterminated string")
+            }
+            LexicalError::UserError { start, end, message } => make_err(start, end, &message),
         },
     }
 }
 
 fn parse(input: &str) -> Result<ast::Program, Error> {
-    polylang::ProgramParser::new()
-        .parse(input)
-        .map_err(|e| parse_error_to_error(input, e))
+    polylang_parser::parse(input).map_err(|e| parse_error_to_error(input, e))
 }
 
 fn parse_out_json(input: &str) -> String {
@@ -144,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_collection() {
-        let program = polylang::ProgramParser::new().parse("collection Test {}");
+        let program = parse("collection Test {}");
 
         let program = program.unwrap();
         assert_eq!(program.nodes.len(), 1);
@@ -155,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_collection_with_fields() {
-        let program = polylang::ProgramParser::new().parse(
+        let program = parse(
             "
             collection Test {
                 name: string;
@@ -185,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_collection_with_asc_desc_fields() {
-        let program = polylang::ProgramParser::new().parse(
+        let program = parse(
             "
             collection Test {
                 asc: string;
@@ -215,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_collection_with_functions() {
-        let program = polylang::ProgramParser::new().parse(
+        let program = parse(
             "
             collection Test {
                 function get_age(a: number, b?: string) {
@@ -258,23 +263,29 @@ mod tests {
 
     #[test]
     fn test_number() {
-        let number = polylang::NumberParser::new().parse("42");
+        let number = polylang_parser::parse_expression("42");
 
         assert!(number.is_ok());
-        assert_eq!(number.unwrap(), 42.0);
+        assert_eq!(
+            number.unwrap(),
+            ast::Expression::Primitive(ast::Primitive::Number(42.0))
+        );
     }
 
     #[test]
     fn test_string() {
-        let string = polylang::StringParser::new().parse("'hello world'");
+        let string = polylang_parser::parse_expression("'hello world'");
 
         assert!(string.is_ok());
-        assert_eq!(string.unwrap(), "hello world");
+        assert_eq!(
+            string.unwrap(),
+            ast::Expression::Primitive(ast::Primitive::String("hello world".to_string()))
+        );
     }
 
     #[test]
     fn test_comparison() {
-        let comparison = polylang::ExpressionParser::new().parse("1 > 2");
+        let comparison = polylang_parser::parse_expression("1 > 2");
 
         assert!(matches!(
             comparison.unwrap(),
@@ -285,17 +296,33 @@ mod tests {
 
     #[test]
     fn test_if() {
-        let if_ = polylang::IfParser::new().parse(
+        let program = parse(
             "
-            if (1 == 1) {
-                return 42;
-            } else {
-                return 0;
+            function x() {
+                if (1 == 1) {
+                    return 42;
+                } else {
+                    return 0;
+                }
             }
             ",
         );
 
-        let if_ = if_.unwrap();
+        let mut program = program.unwrap();
+        assert_eq!(program.nodes.len(), 1);
+
+        let mut function = match program.nodes.pop().unwrap() {
+            ast::RootNode::Function(function) => function,
+            _ => panic!("Expected function"),
+        };
+
+        assert_eq!(function.statements.len(), 1);
+
+        let if_ = match function.statements.pop().unwrap() {
+            ast::Statement::If(if_) => if_,
+            _ => panic!("Expected if"),
+        };
+
         assert!(
             matches!(if_.condition, ast::Expression::Equal(n, m) if *n == ast::Expression::Primitive(ast::Primitive::Number(1.0)) && *m == ast::Expression::Primitive(ast::Primitive::Number(1.0)))
         );
@@ -305,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_call() {
-        let call = polylang::ExpressionParser::new().parse("get_age(a, b, c)");
+        let call = polylang_parser::parse_expression("get_age(a, b, c)");
 
         assert!(matches!(
             call.unwrap(),
@@ -315,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_dot() {
-        let dot = polylang::ExpressionParser::new().parse("a.b").unwrap();
+        let dot = polylang_parser::parse_expression("a.b").unwrap();
 
         assert!(matches!(
             dot,
@@ -325,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_assign_sub() {
-        let dot = polylang::ExpressionParser::new().parse("a -= b").unwrap();
+        let dot = polylang_parser::parse_expression("a -= b").unwrap();
 
         assert!(matches!(
             dot,
@@ -353,7 +380,15 @@ mod tests {
             }
         ";
 
-        let collection = polylang::CollectionParser::new().parse(code).unwrap();
+        let program = parse(code).unwrap();
+
+        assert_eq!(program.nodes.len(), 1);
+
+        let collection = match &program.nodes[0] {
+            ast::RootNode::Collection(collection) => collection,
+            _ => panic!("Expected collection"),
+        };
+
         assert_eq!(collection.name, "Account");
         assert_eq!(collection.items.len(), 6);
 
@@ -684,5 +719,24 @@ name: object;
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_comments() {
+        let code = "
+            collection test {
+                // This is a comment
+                name: string;
+
+                /*
+                    This is a multiline comment
+                */
+                function test() {
+                    return 1;
+                }
+            }
+        ";
+
+        assert!(parse(code).is_ok());
     }
 }


### PR DESCRIPTION
Allows the user to write C-style comments in their code.

```typescript
/*
  multiline
  comment
*/
// single-line comment
```

In https://github.com/polybase/polylang/commit/6c9e620cfb0c64b5f8d5aa4866fea8149aef72f3 I added a script that pulls collections from the testnet. You can test that the parser still parses them correctly by running `cargo test`. I found and fixed one error by doing that - https://github.com/polybase/polylang/commit/82136fcdd0a9c5a18b684732bf1b874fcc914004 (someone had a field named `index` and I changed from parsing "@index" as one token to "@" "index")