### PR TITLE
Implement array#push

### DIFF
--- a/src/compiler/array.rs
+++ b/src/compiler/array.rs
@@ -224,3 +224,125 @@ pub(crate) fn get(compiler: &mut Compiler, arr: &Symbol, index: &Symbol) -> Symb
 
     result
 }
+
+pub(crate) fn find_index(compiler: &mut Compiler, arr: &Symbol, el: &Symbol) -> Result<Symbol> {
+    ensure_eq_type!(arr, Type::Array(_));
+    let element_type = element_type(&arr.type_);
+    ensure_eq_type!(el, @element_type);
+
+    let result = int32::new(compiler, -1);
+
+    let current_arr_element = compiler.memory.allocate_symbol(element_type.clone());
+    let (eq_insts, eq_result) = {
+        let mut insts = Vec::new();
+
+        std::mem::swap(compiler.instructions, &mut insts);
+        // 65, 448
+        let result = super::compile_eq(compiler, el, &current_arr_element);
+        std::mem::swap(compiler.instructions, &mut insts);
+
+        (insts, result)
+    };
+
+    let current_index = compiler
+        .memory
+        .allocate_symbol(Type::PrimitiveType(PrimitiveType::UInt32));
+    let finished = compiler
+        .memory
+        .allocate_symbol(Type::PrimitiveType(PrimitiveType::Boolean));
+
+    iterate_array_elements(
+        compiler,
+        arr,
+        &current_index,
+        &current_arr_element,
+        &finished,
+        eq_insts
+            .into_iter()
+            .chain([Instruction::If {
+                condition: vec![Instruction::MemLoad(Some(eq_result.memory_addr))],
+                then: vec![
+                    Instruction::MemLoad(Some(current_index.memory_addr)),
+                    Instruction::MemStore(Some(result.memory_addr)),
+                    Instruction::Push(1),
+                    Instruction::MemStore(Some(finished.memory_addr)),
+                ],
+                else_: vec![],
+            }])
+            .collect(),
+    )?;
+
+    Ok(result)
+}
+
+fn iterate_array_elements<'a>(
+    compiler: &mut Compiler<'a, '_, '_>,
+    arr: &Symbol,
+    current_element_index: &Symbol,
+    current_element: &Symbol,
+    finished: &Symbol,
+    body: Vec<Instruction<'a>>,
+) -> Result<()> {
+    ensure_eq_type!(arr, Type::Array(_));
+    let element_type = element_type(&arr.type_);
+    ensure_eq_type!(current_element, @element_type);
+
+    compiler.instructions.extend([
+        Instruction::Push(0),
+        // [i = 0]
+        Instruction::While {
+            condition: vec![
+                Instruction::Dup(None),
+                // [i, i]
+                Instruction::MemLoad(Some(length(arr).memory_addr)),
+                // [len, i, i]
+                Instruction::U32CheckedLT,
+                // [i < len, i]
+            ],
+            body: vec![
+                Instruction::Dup(None),
+                // [i, i]
+                Instruction::MemStore(Some(current_element_index.memory_addr)),
+                // [i]
+                Instruction::Dup(None),
+                // [i, i]
+                Instruction::Push(current_element.type_.miden_width()),
+                // [inner_width, i, i]
+                Instruction::U32CheckedMul,
+                // [offset = i * inner_width, i]
+                Instruction::MemLoad(Some(data_ptr(arr).memory_addr)),
+                // [data_ptr, offset, i]
+                Instruction::U32CheckedAdd,
+                // [ptr = data_ptr + offset, i]
+            ]
+            .into_iter()
+            .chain((0..current_element.type_.miden_width()).flat_map(|y| {
+                vec![
+                    Instruction::Dup(None),
+                    // [ptr, ptr, i]
+                    Instruction::Push(y),
+                    // [y, ptr, ptr, i]
+                    Instruction::U32CheckedAdd,
+                    // [ptr + y, ptr, i]
+                    Instruction::MemLoad(None),
+                    // [value, ptr, i]
+                    Instruction::MemStore(Some(current_element.memory_addr + y)),
+                    // [ptr, i]
+                ]
+            }))
+            .chain([Instruction::Drop])
+            .chain(body)
+            .chain([
+                Instruction::Push(1),
+                // [1, i]
+                Instruction::U32CheckedAdd,
+                // [i = i + 1]
+            ])
+            .collect(),
+        },
+        // [i]
+        Instruction::Drop,
+    ]);
+
+    Ok(())
+}

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -19,6 +19,21 @@ use error::prelude::*;
 
 use crate::ast::{self, Expression, Statement};
 
+#[derive(Debug, Clone)]
+enum TypeConstraint {
+    Exact(Type),
+    Array,
+}
+
+impl TypeConstraint {
+    fn matches(&self, type_: &Type) -> bool {
+        match self {
+            TypeConstraint::Exact(expected) => expected == type_,
+            TypeConstraint::Array => matches!(type_, Type::Array(_)),
+        }
+    }
+}
+
 macro_rules! comment {
     ($compiler:expr, $($arg:tt)*) => {
         #[cfg(debug_assertions)]
@@ -79,7 +94,7 @@ lazy_static::lazy_static! {
         for (name, type_, func) in HIDDEN_BUILTINS.iter() {
             match type_ {
                 None => scope.add_function(name.clone(), func.clone()),
-                Some(type_) => scope.add_method(type_.clone(), name.clone(), func.clone()),
+                Some(type_) => scope.add_method(TypeConstraint::Exact(type_.clone()), name.clone(), func.clone()),
             }
         }
 
@@ -424,7 +439,7 @@ lazy_static::lazy_static! {
 
        Box::leak(Box::new(builtins))
     };
-    static ref USABLE_BUILTINS: &'static [(String, Option<Type>, Function<'static>)] = {
+    static ref USABLE_BUILTINS: &'static [(String, Option<TypeConstraint>, Function<'static>)] = {
         let mut builtins = Vec::new();
 
         builtins.push((
@@ -787,12 +802,27 @@ lazy_static::lazy_static! {
 
         builtins.push((
             "toHex".to_string(),
-            Some(Type::PublicKey),
+            Some(TypeConstraint::Exact(Type::PublicKey)),
             Function::Builtin(Box::new(&|compiler, _, args| {
                 let old_root_scope = compiler.root_scope;
                 compiler.root_scope = &BUILTINS_SCOPE;
                 let result = publickey::to_hex(compiler, args);
                 compiler.root_scope = old_root_scope;
+                Ok(result)
+            })),
+        ));
+
+        builtins.push((
+            "indexOf".to_string(),
+            Some(TypeConstraint::Array),
+            Function::Builtin(Box::new(&|compiler, _, args| {
+                ensure!(args.len() == 2, ArgumentsCountSnafu { found: args.len(), expected: 2usize });
+
+                let old_root_scope = compiler.root_scope;
+                compiler.root_scope = &BUILTINS_SCOPE;
+                let result = array::find_index(compiler, &args[0], &args[1])?;
+                compiler.root_scope = old_root_scope;
+
                 Ok(result)
             })),
         ));
@@ -940,7 +970,7 @@ pub(crate) struct Scope<'ast, 'b> {
     symbols: Vec<(String, Symbol)>,
     non_null_symbol_addrs: Vec<u32>,
     functions: Vec<(String, Function<'ast>)>,
-    methods: Vec<(Type, String, Function<'ast>)>,
+    methods: Vec<(TypeConstraint, String, Function<'ast>)>,
     collections: Vec<(String, Collection<'ast>)>,
 }
 
@@ -1011,7 +1041,7 @@ impl<'ast> Scope<'ast, '_> {
         None
     }
 
-    fn add_method(&mut self, type_: Type, name: String, function: Function<'ast>) {
+    fn add_method(&mut self, type_: TypeConstraint, name: String, function: Function<'ast>) {
         self.methods.push((type_, name, function));
     }
 
@@ -1020,7 +1050,7 @@ impl<'ast> Scope<'ast, '_> {
             .methods
             .iter()
             .rev()
-            .find(|(t, n, _)| t == type_ && n == name)
+            .find(|(t, n, _)| n == name && t.matches(type_))
             .map(|(_, _, f)| f)
         {
             return Some(func);
@@ -2124,6 +2154,9 @@ fn compile_eq(compiler: &mut Compiler, a: &Symbol, b: &Symbol) -> Symbol {
 
             uint64::eq(compiler, a, &b_u64)
         }
+        (Type::PrimitiveType(PrimitiveType::Int32), Type::PrimitiveType(PrimitiveType::Int32)) => {
+            uint32::eq(compiler, a, b)
+        }
         (
             Type::PrimitiveType(PrimitiveType::Float32),
             Type::PrimitiveType(PrimitiveType::Float32),
@@ -2401,6 +2434,12 @@ fn compile_index(compiler: &mut Compiler, a: &Symbol, b: &Symbol) -> Result<Symb
             ensure_eq_type!(@k.as_ref(), @&b.type_);
 
             let (_key, value, _value_ptr, _found) = map::get(compiler, a, b)?;
+            Ok(value)
+        }
+        Type::Array(_) => {
+            ensure_eq_type!(@b.type_, @Type::PrimitiveType(PrimitiveType::UInt32));
+
+            let value = array::get(compiler, a, b);
             Ok(value)
         }
         x => TypeMismatchSnafu {


### PR DESCRIPTION
Includes #97 because we need the `TypeConstraint` to implement the push on all Type::Array(_) (any inner element) types.