### PR TITLE
ENG-1070: Alias `contract` to `collection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go run .
 
 You can use the `compile` binary to compile Polylang functions to Miden. Compile outputs the generated Miden assembly to stdout, you can pipe it to `miden-run` to run it.
 
-### Example of compiling and running a collection function
+### Example of compiling and running a contract function
 
 ```bash
  $ cargo run --bin compile -- contract:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }'
@@ -48,7 +48,7 @@ You can use the `compile` binary to compile Polylang functions to Miden. Compile
 cargo test && (cd parser && cargo test)
 ```
 
-You can download and test that collections from the testnet still parse by running:
+You can download and test that contracts from the testnet still parse by running:
 
 ```bash
 ./pull-collections && cargo test

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ You can use the `compile` binary to compile Polylang functions to Miden. Compile
 ### Example of compiling and running a collection function
 
 ```bash
- $ cargo run --bin compile -- collection:Account function:setName <<<'@public collection Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }'
+ $ cargo run --bin compile -- collection:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }'
 
- $ cargo run --bin compile -- collection:Account function:setName <<<'@public collection Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }' \
+ $ cargo run --bin compile -- collection:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }' \
   | cargo run -p miden-run -- \
     --this-json '{ "id": "id1", "name": "John" }' \
     --advice-tape-json '["Tom"]'

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ You can use the `compile` binary to compile Polylang functions to Miden. Compile
 ### Example of compiling and running a collection function
 
 ```bash
- $ cargo run --bin compile -- collection:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }'
+ $ cargo run --bin compile -- contract:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }'
 
- $ cargo run --bin compile -- collection:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }' \
+ $ cargo run --bin compile -- contract:Account function:setName <<<'@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }' \
   | cargo run -p miden-run -- \
     --this-json '{ "id": "id1", "name": "John" }' \
     --advice-tape-json '["Tom"]'

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -92,8 +92,10 @@ pub enum Type {
     #[default]
     String,
     Bytes,
-    CollectionReference {
-        collection: String,
+    #[serde(rename = "CollectionReference")]
+    ContractReference {
+        #[serde(rename = "collection")]
+        contract: String,
     },
     Array(Box<Type>),
     Map(Box<Type>, Box<Type>),
@@ -112,7 +114,7 @@ impl Type {
             Type::PrimitiveType(pt) => pt.miden_width(),
             Type::String => STRING_MIDEN_WIDTH,
             Type::Bytes => BYTES_MIDEN_WIDTH,
-            Type::CollectionReference { .. } => BYTES_MIDEN_WIDTH,
+            Type::ContractReference { .. } => BYTES_MIDEN_WIDTH,
             Type::Array(_) => ARRAY_MIDEN_WIDTH,
             Type::Map(_, _) => MAP_MIDEN_WIDTH,
             Type::Hash => 4,
@@ -134,7 +136,7 @@ impl Type {
             Type::PrimitiveType(PrimitiveType::Float64) => Value::Float64(0.0),
             Type::String => Value::String("".to_owned()),
             Type::Bytes => Value::Bytes(vec![]),
-            Type::CollectionReference { .. } => Value::CollectionReference(Vec::new()),
+            Type::ContractReference { .. } => Value::CollectionReference(Vec::new()),
             Type::Array(_) => Value::Array(Vec::new()),
             Type::Map(_, _) => Value::Map(Vec::new()),
             Type::Hash => Value::Hash([0; 4]),
@@ -464,7 +466,7 @@ impl TypeReader for Type {
 
                 Ok(Value::Bytes(bytes))
             }
-            Type::CollectionReference { .. } => {
+            Type::ContractReference { .. } => {
                 let mut bytes = vec![];
 
                 let length = reader(addr).context(InvalidAddressSnafu {
@@ -735,7 +737,7 @@ impl Parser<str> for Type {
                 }
                 Ok(Value::Bytes(bytes))
             }
-            Type::CollectionReference { .. } => {
+            Type::ContractReference { .. } => {
                 let mut bytes = vec![];
                 if !value.is_empty() {
                     for byte in value.split(',') {
@@ -902,7 +904,7 @@ impl Parser<serde_json::Value> for Type {
                 }
                 Ok(Value::Bytes(bytes))
             }
-            Type::CollectionReference { .. } => {
+            Type::ContractReference { .. } => {
                 let mut bytes = vec![];
                 if !value.is_null() {
                     // let collection_id = value

--- a/js/src/ast.ts
+++ b/js/src/ast.ts
@@ -1,12 +1,12 @@
 export type Root = Node[]
 
-export type Node = Collection | { kind: string }
+export type Node = Contract | { kind: string }
 
-export interface Collection {
-  kind: 'collection'
+export interface Contract {
+  kind: 'contract'
   namespace: Namespace
   name: string
-  attributes: CollectionAttribute[]
+  attributes: ContractAttribute[]
 }
 
 export interface Namespace {
@@ -14,7 +14,7 @@ export interface Namespace {
   value: string
 }
 
-export type CollectionAttribute = Property | Index | Method | Directive
+export type ContractAttribute = Property | Index | Method | Directive
 
 export interface Property {
   kind: 'property',
@@ -83,7 +83,7 @@ export interface ObjectField {
 
 export interface ForeignRecord {
   kind: 'foreignrecord',
-  collection: string
+  contract: string
 }
 
 export interface PublicKey {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -11,21 +11,21 @@ export interface Program {
 }
 
 export interface RootNode {
-  Collection: Collection
+  Contract: Contract
   Function: Function
 }
 
-export type Collection = any
+export type Contract = any
 export type Function = any
 
 export async function parse(code: string, namespace: string): Promise<[Program, any]> {
   return unwrap(JSON.parse((await parser).parse(code, namespace)))
 }
 
-export interface JSCollection {
+export interface JSContract {
   code: string
 }
 
-export async function generateJSCollection(collection: any): Promise<JSCollection> {
-  return unwrap(JSON.parse((await parser).generate_js_collection(JSON.stringify(collection))))
+export async function generateJSContract(contract: any): Promise<JSContract> {
+  return unwrap(JSON.parse((await parser).generate_js_contract(JSON.stringify(contract))))
 }

--- a/js/src/validator/index.ts
+++ b/js/src/validator/index.ts
@@ -5,6 +5,6 @@ const parser = import('../../pkg-thin/index.js').then(p => p.default).then(p => 
   return p
 })
 
-export async function validateSet (collectionAST: any, data: { [k: string]: any }): Promise<void> {
-  return unwrap(JSON.parse((await parser).validate_set(JSON.stringify(collectionAST), JSON.stringify(data))))
+export async function validateSet(contractAST: any, data: { [k: string]: any }): Promise<void> {
+  return unwrap(JSON.parse((await parser).validate_set(JSON.stringify(contractAST), JSON.stringify(data))))
 }

--- a/miden-run/src/main.rs
+++ b/miden-run/src/main.rs
@@ -9,7 +9,7 @@ struct Args {
     advice_tape_json: Option<String>,
     this_values: HashMap<String, String>,
     this_json: Option<serde_json::Value>,
-    /// Map of collection name to a list of records and field salts
+    /// Map of contract name to a list of records and field salts
     other_records: HashMap<String, Vec<(serde_json::Value, Vec<u32>)>>,
     abi: Abi,
     ctx: Ctx,
@@ -63,7 +63,7 @@ impl Args {
                     this_json = Some(this_value);
                 }
                 "--other-record" => {
-                    let collection_name = args
+                    let contract_name = args
                         .next()
                         .ok_or_else(|| format!("missing value for argument {}", arg))?;
 
@@ -77,7 +77,7 @@ impl Args {
                         })?;
 
                     other_records
-                        .entry(collection_name)
+                        .entry(contract_name)
                         .or_insert_with(Vec::new)
                         .push((record_json, vec![]));
                 }
@@ -131,9 +131,9 @@ impl Args {
             Some(abi) => abi,
         };
 
-        for (collection, records) in other_records.iter_mut() {
-            let col_struct = abi.other_collection_types.iter().find_map(|t| match t {
-                abi::Type::Struct(s) if s.name == *collection => Some(s),
+        for (contract, records) in other_records.iter_mut() {
+            let col_struct = abi.other_contract_types.iter().find_map(|t| match t {
+                abi::Type::Struct(s) if s.name == *contract => Some(s),
                 _ => None,
             });
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -7,19 +7,19 @@ pub struct Program {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum RootNode {
-    Collection(Collection),
+    Contract(Contract),
     Function(Function),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Collection {
+pub struct Contract {
     pub name: String,
     pub decorators: Vec<Decorator>,
-    pub items: Vec<CollectionItem>,
+    pub items: Vec<ContractItem>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum CollectionItem {
+pub enum ContractItem {
     Field(Field),
     Function(Function),
     Index(Index),
@@ -63,7 +63,7 @@ pub enum Type {
     Map(Box<Type>, Box<Type>),
     Object(Vec<Field>),
     PublicKey,
-    ForeignRecord { collection: String },
+    ForeignRecord { contract: String },
     Bytes,
 }
 
@@ -83,7 +83,7 @@ pub enum ParameterType {
     Map(Type, Type),
     Object(Vec<(String, Type)>),
     Record,
-    ForeignRecord { collection: String },
+    ForeignRecord { contract: String },
     PublicKey,
     Bytes,
 }
@@ -159,7 +159,9 @@ impl<T> MaybeSpanned<T> {
     }
 
     pub fn span(&self) -> Option<Span> {
-        let Self::Spanned(spanned) = self else { return None };
+        let Self::Spanned(spanned) = self else {
+            return None;
+        };
         Some(spanned.span)
     }
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -113,7 +113,7 @@ impl std::fmt::Display for Tok<'_> {
             Tok::Of => write!(f, "of"),
             Tok::Function => write!(f, "function"),
             Tok::Index => write!(f, "index"),
-            Tok::Collection => write!(f, "collection"),
+            Tok::Collection => write!(f, "contract"),
             Tok::Contract => write!(f, "contract"),
             Tok::LBrace => write!(f, "{{"),
             Tok::RBrace => write!(f, "}}"),

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -38,6 +38,7 @@ pub enum Tok<'input> {
     Function,
     Index,
     Collection,
+    Contract,
     LBrace,
     RBrace,
     LBracket,
@@ -113,6 +114,7 @@ impl std::fmt::Display for Tok<'_> {
             Tok::Function => write!(f, "function"),
             Tok::Index => write!(f, "index"),
             Tok::Collection => write!(f, "collection"),
+            Tok::Contract => write!(f, "contract"),
             Tok::LBrace => write!(f, "{{"),
             Tok::RBrace => write!(f, "}}"),
             Tok::LBracket => write!(f, "["),
@@ -233,7 +235,7 @@ const KEYWORDS: &[(Tok, &str)] = &[
     (Tok::Function, "function"),
     (Tok::Index, "@index"),
     (Tok::Collection, "collection"),
-    (Tok::Collection, "contract"),
+    (Tok::Contract, "contract"),
     (Tok::PublicKey, "PublicKey"),
     (Tok::Bytes, "bytes"),
 ];
@@ -814,7 +816,7 @@ mod tests {
         let input = "contract collection";
         let mut lexer = Lexer::new(input);
 
-        assert_eq!(lexer.next(), Some(Ok((0, Tok::Collection, 8))));
+        assert_eq!(lexer.next(), Some(Ok((0, Tok::Contract, 8))));
         assert_eq!(lexer.next(), Some(Ok((9, Tok::Collection, 19))));
     }
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -233,6 +233,7 @@ const KEYWORDS: &[(Tok, &str)] = &[
     (Tok::Function, "function"),
     (Tok::Index, "@index"),
     (Tok::Collection, "collection"),
+    (Tok::Collection, "contract"),
     (Tok::PublicKey, "PublicKey"),
     (Tok::Bytes, "bytes"),
 ];
@@ -806,6 +807,15 @@ mod tests {
         assert_eq!(lexer.next(), Some(Ok((5, Tok::Asc, 8))));
         assert_eq!(&input[5..8], "asc");
         assert_eq!(lexer.next(), None);
+    }
+
+    #[test]
+    fn test_lex_keyword_contract() {
+        let input = "contract collection";
+        let mut lexer = Lexer::new(input);
+
+        assert_eq!(lexer.next(), Some(Ok((0, Tok::Collection, 8))));
+        assert_eq!(lexer.next(), Some(Ok((9, Tok::Collection, 19))));
     }
 
     #[test]

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -44,7 +44,7 @@ extern {
         "function" => lexer::Tok::Function,
         "@index" => lexer::Tok::Index,
         "collection" => lexer::Tok::Collection,
-        "contract" => lexer::Tok::Collection,
+        "contract" => lexer::Tok::Contract,
         "eth#" => lexer::Tok::EthLiteralStart,
         "falcon#" => lexer::Tok::FalconLiteralStart,
         "{" => lexer::Tok::LBrace,

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -44,6 +44,7 @@ extern {
         "function" => lexer::Tok::Function,
         "@index" => lexer::Tok::Index,
         "collection" => lexer::Tok::Collection,
+        "contract" => lexer::Tok::Collection,
         "eth#" => lexer::Tok::EthLiteralStart,
         "falcon#" => lexer::Tok::FalconLiteralStart,
         "{" => lexer::Tok::LBrace,
@@ -531,7 +532,12 @@ CollectionItem: CollectionItem = {
 };
 
 Collection: Collection = {
-    <decorators:Decorator*> "collection" <name:Ident> "{" <items:CollectionItem*> "}" => Collection {
+    <decorators:Decorator*>  "collection" <name:Ident> "{" <items:CollectionItem*> "}" => Collection {
+        name: name,
+        decorators: decorators,
+        items: items,
+    },
+    <decorators:Decorator*>  "contract" <name:Ident> "{" <items:CollectionItem*> "}" => Collection {
         name: name,
         decorators: decorators,
         items: items,

--- a/parser/src/polylang.lalrpop
+++ b/parser/src/polylang.lalrpop
@@ -107,7 +107,7 @@ BasicType: Type = {
 ArrayInnerType: Type = {
     <t:BasicType> => t,
     <i:Ident> => Type::ForeignRecord {
-        collection: i,
+        contract: i,
     },
 }
 
@@ -117,7 +117,7 @@ Type: Type = {
     "map" "<" <kt:BasicType> "," <vt:Type> ">" => Type::Map(Box::new(kt), Box::new(vt)),
     "{" <fields:(Field ";")*> "}" => Type::Object(fields.into_iter().map(|(f, _)| f).collect()),
     <i:Ident> => Type::ForeignRecord {
-        collection: i,
+        contract: i,
     },
 };
 
@@ -143,7 +143,7 @@ ParameterType: ParameterType = {
             }
         }),
         Type::PublicKey => Ok(ParameterType::PublicKey),
-        Type::ForeignRecord { collection } => Ok(ParameterType::ForeignRecord { collection }),
+        Type::ForeignRecord { contract } => Ok(ParameterType::ForeignRecord { contract }),
     },
     "record" => ParameterType::Record,
 };
@@ -525,19 +525,19 @@ IndexFields: Vec<IndexField> = {
     => vec![],
 };
 
-CollectionItem: CollectionItem = {
-    <f:Field> ";" => CollectionItem::Field(f),
-    <i:Index> ";" => CollectionItem::Index(i),
-    <f:Function> => CollectionItem::Function(f),
+ContractItem: ContractItem = {
+    <f:Field> ";" => ContractItem::Field(f),
+    <i:Index> ";" => ContractItem::Index(i),
+    <f:Function> => ContractItem::Function(f),
 };
 
-Collection: Collection = {
-    <decorators:Decorator*>  "collection" <name:Ident> "{" <items:CollectionItem*> "}" => Collection {
+Contract: Contract = {
+    <decorators:Decorator*>  "contract" <name:Ident> "{" <items:ContractItem*> "}" => Contract {
         name: name,
         decorators: decorators,
         items: items,
     },
-    <decorators:Decorator*>  "contract" <name:Ident> "{" <items:CollectionItem*> "}" => Collection {
+    <decorators:Decorator*>  "collection" <name:Ident> "{" <items:ContractItem*> "}" => Contract {
         name: name,
         decorators: decorators,
         items: items,
@@ -545,7 +545,7 @@ Collection: Collection = {
 };
 
 RootNode: RootNode = {
-    <c:Collection> => RootNode::Collection(c),
+    <c:Contract> => RootNode::Contract(c),
     <f:RootFunction> => RootNode::Function(f),
 };
 

--- a/pull-collections
+++ b/pull-collections
@@ -37,6 +37,9 @@ while True:
         id = collection.get('id', '')
         code = collection.get('code', '')
 
+        # replace `contract`(exact match) with `_contract`
+        code = re.sub(r'\bcontract\b', '_contract', code)
+
         # Keep only alphanumeric characters and replace others with '-'
         filename = re.sub(r'[^a-zA-Z0-9]', '-', id)
 

--- a/src/bin/compile/main.rs
+++ b/src/bin/compile/main.rs
@@ -4,13 +4,13 @@ fn main() {
     let mut code = String::new();
     std::io::stdin().read_to_string(&mut code).unwrap();
 
-    let mut collection_name = None;
+    let mut contract_name = None;
     let mut function_name = "main".to_string();
 
     for arg in std::env::args().skip(1) {
         match arg.split_once(':') {
             Some((key, value)) => match key {
-                "collection" => collection_name = Some(value.to_string()),
+                "contract" => contract_name = Some(value.to_string()),
                 "function" => function_name = value.to_string(),
                 _ => panic!("unknown argument: {}", key),
             },
@@ -21,7 +21,7 @@ fn main() {
     let program = polylang_parser::parse(&code).unwrap();
 
     let (miden_code, abi) =
-        polylang::compiler::compile(program, collection_name.as_deref(), &function_name)
+        polylang::compiler::compile(program, contract_name.as_deref(), &function_name)
             .map_err(|e| e.add_source(code))
             .unwrap_or_else(|e| panic!("{e}"));
     println!("{}", miden_code);

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -30,8 +30,8 @@ pub fn validate_set(ast_json: &str, data_json: &str) -> String {
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn generate_js_collection(collection_ast_json: &str) -> String {
-    crate::generate_js_collection_out_json(collection_ast_json)
+pub fn generate_js_contract(contract_ast_json: &str) -> String {
+    crate::generate_js_contract_out_json(contract_ast_json)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -65,11 +65,11 @@ pub extern "C" fn validate_set(ast_json: *const c_char, data_json: *const c_char
 
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
-pub extern "C" fn generate_js_collection(collection_ast_json: *const c_char) -> *mut c_char {
-    let collection_ast_json = unsafe { std::ffi::CStr::from_ptr(collection_ast_json) };
-    let collection_ast_json = collection_ast_json.to_str().unwrap();
+pub extern "C" fn generate_js_contract(contract_ast_json: *const c_char) -> *mut c_char {
+    let contract_ast_json = unsafe { std::ffi::CStr::from_ptr(contract_ast_json) };
+    let contract_ast_json = contract_ast_json.to_str().unwrap();
 
-    let output = crate::generate_js_collection_out_json(collection_ast_json);
+    let output = crate::generate_js_contract_out_json(contract_ast_json);
     let output = std::ffi::CString::new(output).unwrap();
     output.into_raw()
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2194,8 +2194,8 @@ fn compile_ast_function_call(
             Some(ast::Type::String) => Type::String,
             Some(ast::Type::PublicKey) => Type::PublicKey,
             Some(ast::Type::Bytes) => Type::Bytes,
-            Some(ast::Type::ForeignRecord { collection }) => Type::CollectionReference {
-                collection: collection.clone(),
+            Some(ast::Type::ForeignRecord { contract }) => Type::CollectionReference {
+                collection: contract.clone(),
             },
             Some(ast::Type::Boolean) => {
                 return Err(Error::simple("unexpected function call of boolean"))
@@ -3664,7 +3664,7 @@ fn prepare_scope(program: &ast::Program) -> Scope {
 
     for node in &program.nodes {
         match node {
-            ast::RootNode::Collection(c) => {
+            ast::RootNode::Contract(c) => {
                 let mut collection = Collection {
                     name: c.name.clone(),
                     functions: vec![],
@@ -3695,7 +3695,7 @@ fn prepare_scope(program: &ast::Program) -> Scope {
 
                 for item in &c.items {
                     match item {
-                        ast::CollectionItem::Field(f) => {
+                        ast::ContractItem::Field(f) => {
                             collection.fields.push(CollectionField {
                                 name: f.name.clone(),
                                 type_: ast_type_to_type(f.required, &f.type_),
@@ -3703,10 +3703,10 @@ fn prepare_scope(program: &ast::Program) -> Scope {
                                 read: f.decorators.iter().any(|d| d.name == "read"),
                             });
                         }
-                        ast::CollectionItem::Function(f) => {
+                        ast::ContractItem::Function(f) => {
                             collection.functions.push((f.name.clone(), f));
                         }
-                        ast::CollectionItem::Index(_) => {}
+                        ast::ContractItem::Index(_) => {}
                     }
                 }
 
@@ -4581,8 +4581,8 @@ fn ast_param_type_to_type(
         ast::ParameterType::Record => Type::Struct(collection_struct.unwrap().clone()),
         ast::ParameterType::PublicKey => Type::PublicKey,
         ast::ParameterType::Bytes => Type::Bytes,
-        ast::ParameterType::ForeignRecord { collection } => Type::CollectionReference {
-            collection: collection.clone(),
+        ast::ParameterType::ForeignRecord { contract } => Type::CollectionReference {
+            collection: contract.clone(),
         },
         ast::ParameterType::Array(t) => Type::Array(Box::new(ast_type_to_type(true, t))),
         ast::ParameterType::Boolean => {
@@ -4620,8 +4620,8 @@ fn ast_type_to_type(required: bool, type_: &ast::Type) -> Type {
         ast::Type::I64 => Type::PrimitiveType(PrimitiveType::Int64),
         ast::Type::PublicKey => Type::PublicKey,
         ast::Type::Bytes => Type::Bytes,
-        ast::Type::ForeignRecord { collection } => Type::CollectionReference {
-            collection: collection.clone(),
+        ast::Type::ForeignRecord { contract } => Type::CollectionReference {
+            collection: contract.clone(),
         },
         ast::Type::Array(t) => Type::Array(Box::new(ast_type_to_type(true, t))),
         ast::Type::Boolean => Type::PrimitiveType(PrimitiveType::Boolean),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -4359,17 +4359,10 @@ fn compile_check_eq_or_ownership(
         .allocate_symbol(Type::PrimitiveType(PrimitiveType::Boolean));
 
     let is_eq = match &field.type_ {
-<<<<<<< HEAD
         Type::PublicKey => compile_eq(compiler, &field, auth_pk)?,
         Type::Nullable(t) if **t == Type::PublicKey => compile_eq(compiler, &field, auth_pk)?,
-        Type::CollectionReference { collection } => {
-            let collection_type = compiler.root_scope.find_collection(&collection).unwrap();
-=======
-        Type::PublicKey => compile_eq(compiler, &field, auth_pk),
-        Type::Nullable(t) if **t == Type::PublicKey => compile_eq(compiler, &field, auth_pk),
         Type::ContractReference { contract } => {
             let collection_type = compiler.root_scope.find_collection(&contract).unwrap();
->>>>>>> 5b6355c (Changes:)
             let collection_record_hashes = compiler.get_record_dependency(collection_type).unwrap();
             let id = struct_field(compiler, &field, "id").unwrap();
 

--- a/src/compiler/string.rs
+++ b/src/compiler/string.rs
@@ -789,7 +789,7 @@ pub(crate) fn hash(compiler: &mut Compiler, _scope: &Scope, args: &[Symbol]) -> 
     let string = &args[0];
     ensure_eq_type!(
         string,
-        Type::String | Type::Bytes | Type::CollectionReference { .. }
+        Type::String | Type::Bytes | Type::ContractReference { .. }
     );
 
     let result = compiler.memory.allocate_symbol(Type::Hash);

--- a/src/js.rs
+++ b/src/js.rs
@@ -2,16 +2,16 @@ use crate::stableast;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, PartialEq)]
-pub struct JSCollection {
+pub struct JSContract {
     pub code: String,
 }
 
-pub fn generate_js_collection(collection_ast: &stableast::Collection) -> JSCollection {
-    let fns = collection_ast
+pub fn generate_js_contract(contract_ast: &stableast::Contract) -> JSContract {
+    let fns = contract_ast
         .attributes
         .iter()
         .filter_map(|item| {
-            if let stableast::CollectionAttribute::Method(m) = item {
+            if let stableast::ContractAttribute::Method(m) = item {
                 let JSFunc { name, code } = generate_js_function(m);
                 Some(format!("instance.{} = {}", &name, &code))
             } else {
@@ -21,7 +21,7 @@ pub fn generate_js_collection(collection_ast: &stableast::Collection) -> JSColle
         .collect::<Vec<String>>()
         .join(";");
 
-    JSCollection {
+    JSContract {
         code: format!(
             "function error(str) {{
                 return new Error(str);
@@ -107,12 +107,12 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_collection_function() {
-        let collection_ast = stableast::Collection {
+    fn test_generate_contract_function() {
+        let contract_ast = stableast::Contract {
             namespace: stableast::Namespace { value: "".into() },
-            name: "CollectionName".into(),
+            name: "ContractName".into(),
             attributes: vec![
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "abc".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::String,
@@ -120,7 +120,7 @@ mod tests {
                     directives: vec![],
                     required: true,
                 }),
-                stableast::CollectionAttribute::Method(stableast::Method {
+                stableast::ContractAttribute::Method(stableast::Method {
                     name: "Hello".into(),
                     attributes: vec![
                         stableast::MethodAttribute::Parameter(stableast::Parameter {
@@ -146,7 +146,7 @@ mod tests {
                     ],
                     code: "return a".into(),
                 }),
-                stableast::CollectionAttribute::Method(stableast::Method {
+                stableast::ContractAttribute::Method(stableast::Method {
                     name: "World".into(),
                     attributes: vec![
                         stableast::MethodAttribute::Parameter(stableast::Parameter {
@@ -176,8 +176,8 @@ mod tests {
         };
 
         assert_eq!(
-            generate_js_collection(&collection_ast),
-            JSCollection{
+            generate_js_contract(&contract_ast),
+            JSContract{
                 code: "function error(str) {
                 return new Error(str);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_contract() {
+        let input = "contract Test {}";
+        let expected_output = expect![[
+            r#"{"Ok":[{"nodes":[{"Collection":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
+        ]];
+
+        let output = parse_out_json(input, "");
+        expected_output.assert_eq(&output);
+    }
+
+    #[test]
     fn test_parse_collection_metadata() {
         let input = "@public collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; ast?: string; publicKey?: PublicKey; @index(publicKey); @index([lastRecordUpdated, desc]); constructor (id: string, code: string) { this.id = id; this.code = code; this.ast = parse(code); if (ctx.publicKey) this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error('invalid owner'); } this.code = code; this.ast = parse(code); } }";
         let expected_output = expect![[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ mod tests {
     fn test_parse() {
         let input = "collection Test {}";
         let expected_output = expect![[
-            r#"{"Ok":[{"nodes":[{"Collection":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
+            r#"{"Ok":[{"nodes":[{"Contract":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
         ]];
 
         let output = parse_out_json(input, "");
@@ -188,7 +188,7 @@ mod tests {
     fn test_parse_contract() {
         let input = "contract Test {}";
         let expected_output = expect![[
-            r#"{"Ok":[{"nodes":[{"Collection":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
+            r#"{"Ok":[{"nodes":[{"Contract":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
         ]];
 
         let output = parse_out_json(input, "");
@@ -216,7 +216,7 @@ mod tests {
 
         assert_eq!(program.nodes.len(), 1);
         assert!(
-            matches!(&program.nodes[0], ast::RootNode::Collection(ast::Collection { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.is_empty())
+            matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.is_empty())
         );
     }
 
@@ -237,19 +237,19 @@ mod tests {
 
         assert_eq!(program.nodes.len(), 1);
         assert!(
-            matches!(&program.nodes[0], ast::RootNode::Collection(ast::Collection { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 2)
+            matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 2)
         );
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(collection) => collection,
+            ast::RootNode::Contract(contract) => contract,
             _ => panic!("Expected collection"),
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "name" && *type_ == ast::Type::String && decorators.is_empty())
+            matches!(&collection.items[0], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "name" && *type_ == ast::Type::String && decorators.is_empty())
         );
         assert!(
-            matches!(&collection.items[1], ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "age" && *type_ == ast::Type::Number && decorators.is_empty())
+            matches!(&collection.items[1], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "age" && *type_ == ast::Type::Number && decorators.is_empty())
         );
     }
 
@@ -270,19 +270,19 @@ mod tests {
 
         assert_eq!(program.nodes.len(), 1);
         assert!(
-            matches!(&program.nodes[0], ast::RootNode::Collection(ast::Collection { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 2)
+            matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 2)
         );
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(collection) => collection,
+            ast::RootNode::Contract(contract) => contract,
             _ => panic!("Expected collection"),
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "asc" && *type_ == ast::Type::String && decorators.is_empty()),
+            matches!(&collection.items[0], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "asc" && *type_ == ast::Type::String && decorators.is_empty()),
         );
         assert!(
-            matches!(&collection.items[1], ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "desc" && *type_ == ast::Type::String && decorators.is_empty()),
+            matches!(&collection.items[1], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "desc" && *type_ == ast::Type::String && decorators.is_empty()),
         );
     }
 
@@ -304,16 +304,16 @@ mod tests {
 
         assert_eq!(program.nodes.len(), 1);
         assert!(
-            matches!(&program.nodes[0], ast::RootNode::Collection(ast::Collection { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 1)
+            matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 1)
         );
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(collection) => collection,
+            ast::RootNode::Contract(contract) => contract,
             _ => panic!("Expected collection"),
         };
 
         assert!(
-            matches!(&collection.items[0], ast::CollectionItem::Function(ast::Function {
+            matches!(&collection.items[0], ast::ContractItem::Function(ast::Function {
                 name,
                 decorators,
                 parameters,
@@ -324,7 +324,7 @@ mod tests {
         );
 
         let function = match &collection.items[0] {
-            ast::CollectionItem::Function(function) => function,
+            ast::ContractItem::Function(function) => function,
             _ => panic!("Expected function"),
         };
 
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(program.nodes.len(), 1);
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(collection) => collection,
+            ast::RootNode::Contract(contract) => contract,
             _ => panic!("Expected collection"),
         };
 
@@ -517,38 +517,38 @@ mod tests {
 
         assert!(matches!(
             &collection.items[0],
-            ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators })
+            ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators })
             if name == "name" && *type_ == ast::Type::String && decorators.is_empty()
         ));
 
         assert!(matches!(
             &collection.items[1],
-            ast::CollectionItem::Field(ast::Field { name, type_, required: false, decorators })
+            ast::ContractItem::Field(ast::Field { name, type_, required: false, decorators })
             if name == "age" && *type_ == ast::Type::Number && decorators.is_empty()
         ));
 
         assert!(matches!(
             &collection.items[2],
-            ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators })
+            ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators })
             if name == "balance" && *type_ == ast::Type::Number && decorators.is_empty()
         ));
 
         assert!(matches!(
             &collection.items[3],
-            ast::CollectionItem::Field(ast::Field { name, type_, required: true, decorators })
+            ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators })
             if name == "publicKey" && *type_ == ast::Type::String && decorators.is_empty()
         ));
 
         assert!(matches!(
             &collection.items[4],
-            ast::CollectionItem::Index(ast::Index {
+            ast::ContractItem::Index(ast::Index {
                 fields,
             }) if fields[0].path == ["field"] && fields[0].order == ast::Order::Asc
                 && fields[1].path == ["field2"] && fields[1].order == ast::Order::Asc
         ));
 
         let function = match &collection.items[5] {
-            ast::CollectionItem::Function(f) => f,
+            ast::ContractItem::Function(f) => f,
             _ => panic!("expected function"),
         };
         dbg!(&function.statements);
@@ -698,14 +698,14 @@ function x() {
         let (program, _) = parse(code, "", &mut program).unwrap();
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(c) => c,
+            ast::RootNode::Contract(c) => c,
             _ => panic!("expected collection"),
         };
 
         assert_eq!(collection.items.len(), 1);
 
         let field = match &collection.items[0] {
-            ast::CollectionItem::Field(f) => f,
+            ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
 
@@ -713,7 +713,7 @@ function x() {
         assert_eq!(
             field.type_,
             ast::Type::ForeignRecord {
-                collection: "Account".to_string(),
+                contract: "Account".to_string(),
             }
         );
     }
@@ -764,7 +764,7 @@ function x() {
             let (program, _) = parse(code, "", &mut program).unwrap();
             assert_eq!(program.nodes.len(), 1);
             let collection = match &program.nodes[0] {
-                ast::RootNode::Collection(c) => c,
+                ast::RootNode::Contract(c) => c,
                 _ => panic!("expected collection"),
             };
             assert_eq!(collection.items.len(), expected.len());
@@ -773,7 +773,7 @@ function x() {
                 assert!(
                     matches!(
                         &collection.items[i],
-                        ast::CollectionItem::Field(ast::Field {
+                        ast::ContractItem::Field(ast::Field {
                             name,
                             type_,
                             required,
@@ -853,7 +853,7 @@ function x() {
             let (program, _) = parse(code, "", &mut program).unwrap();
             assert_eq!(program.nodes.len(), 1);
             let collection = match &program.nodes[0] {
-                ast::RootNode::Collection(c) => c,
+                ast::RootNode::Contract(c) => c,
                 _ => panic!("expected collection"),
             };
             assert_eq!(collection.items.len(), expected.len());
@@ -862,7 +862,7 @@ function x() {
                 assert!(
                     matches!(
                         &collection.items[i],
-                        ast::CollectionItem::Field(ast::Field {
+                        ast::ContractItem::Field(ast::Field {
                             name,
                             type_,
                             required,
@@ -913,7 +913,7 @@ function x() {
         assert_eq!(program.nodes.len(), 1);
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(c) => c,
+            ast::RootNode::Contract(c) => c,
             _ => panic!("expected collection"),
         };
         assert_eq!(collection.items.len(), 2);
@@ -921,7 +921,7 @@ function x() {
         assert!(
             matches!(
                 &collection.items[1],
-                ast::CollectionItem::Index(ast::Index {
+                ast::ContractItem::Index(ast::Index {
                     fields,
                 }) if fields == &[ast::IndexField { path: vec!["person".to_string(), "name".to_string()], order: ast::Order::Asc }]
             ),
@@ -949,7 +949,7 @@ function x() {
         assert_eq!(program.nodes.len(), 1);
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(c) => c,
+            ast::RootNode::Contract(c) => c,
             _ => panic!("expected collection"),
         };
 
@@ -959,7 +959,7 @@ function x() {
         assert_eq!(collection.items.len(), 2);
 
         let field = match &collection.items[0] {
-            ast::CollectionItem::Field(f) => f,
+            ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
 
@@ -967,7 +967,7 @@ function x() {
         assert_eq!(field.decorators[0].name, "read");
 
         let function = match &collection.items[1] {
-            ast::CollectionItem::Function(f) => f,
+            ast::ContractItem::Function(f) => f,
             _ => panic!("expected function"),
         };
 
@@ -993,14 +993,14 @@ function x() {
         assert_eq!(program.nodes.len(), 1);
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(c) => c,
+            ast::RootNode::Contract(c) => c,
             _ => panic!("expected collection"),
         };
 
         assert_eq!(collection.items.len(), 1);
 
         let field = match &collection.items[0] {
-            ast::CollectionItem::Field(f) => f,
+            ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
 
@@ -1008,7 +1008,7 @@ function x() {
         assert_eq!(
             field.type_,
             ast::Type::Array(Box::new(ast::Type::ForeignRecord {
-                collection: "Person".to_string()
+                contract: "Person".to_string()
             }))
         );
     }
@@ -1095,14 +1095,14 @@ function x() {
         assert_eq!(program.nodes.len(), 1);
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(c) => c,
+            ast::RootNode::Contract(c) => c,
             _ => panic!("expected collection"),
         };
 
         assert_eq!(collection.items.len(), 2);
 
         let field = match &collection.items[0] {
-            ast::CollectionItem::Field(f) => f,
+            ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
 
@@ -1118,7 +1118,7 @@ function x() {
         );
 
         let function = match &collection.items[1] {
-            ast::CollectionItem::Function(f) => f,
+            ast::ContractItem::Function(f) => f,
             _ => panic!("expected function"),
         };
 
@@ -1158,14 +1158,14 @@ function x() {
         assert_eq!(program.nodes.len(), 1);
 
         let collection = match &program.nodes[0] {
-            ast::RootNode::Collection(c) => c,
+            ast::RootNode::Contract(c) => c,
             _ => panic!("expected collection"),
         };
 
         assert_eq!(collection.items.len(), 2);
 
         let field = match &collection.items[0] {
-            ast::CollectionItem::Field(f) => f,
+            ast::ContractItem::Field(f) => f,
             _ => panic!("expected publicKeys"),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ fn parse_out_json(input: &str, namespace: &str) -> String {
     serde_json::to_string(&parse(input, namespace, &mut None)).unwrap()
 }
 
-fn validate_set(collection_ast_json: &str, data_json: &str) -> Result<(), Error> {
-    let collection_ast: stableast::Collection = match serde_json::from_str(collection_ast_json) {
+fn validate_set(contract_ast_json: &str, data_json: &str) -> Result<(), Error> {
+    let contract_ast: stableast::Contract = match serde_json::from_str(contract_ast_json) {
         Ok(ast) => ast,
         Err(err) => {
             return Err(Error {
@@ -145,26 +145,26 @@ fn validate_set(collection_ast_json: &str, data_json: &str) -> Result<(), Error>
         }
     };
 
-    validation::validate_set(&collection_ast, &data).map_err(|e| Error {
+    validation::validate_set(&contract_ast, &data).map_err(|e| Error {
         message: e.to_string(),
     })
 }
 
-fn validate_set_out_json(collection_ast_json: &str, data_json: &str) -> String {
-    serde_json::to_string(&validate_set(collection_ast_json, data_json)).unwrap()
+fn validate_set_out_json(contract_ast_json: &str, data_json: &str) -> String {
+    serde_json::to_string(&validate_set(contract_ast_json, data_json)).unwrap()
 }
 
-fn generate_collection_function(collection_ast: &str) -> Result<js::JSCollection, Error> {
-    let collection_ast: stableast::Collection =
-        serde_json::from_str(collection_ast).map_err(|e| Error {
+fn generate_contract_function(contract_ast: &str) -> Result<js::JSContract, Error> {
+    let contract_ast: stableast::Contract =
+        serde_json::from_str(contract_ast).map_err(|e| Error {
             message: e.to_string(),
         })?;
 
-    Ok(js::generate_js_collection(&collection_ast))
+    Ok(js::generate_js_contract(&contract_ast))
 }
 
-fn generate_js_collection_out_json(collection_ast: &str) -> String {
-    serde_json::to_string(&generate_collection_function(collection_ast)).unwrap()
+fn generate_js_contract_out_json(contract_ast: &str) -> String {
+    serde_json::to_string(&generate_contract_function(contract_ast)).unwrap()
 }
 
 #[cfg(test)]
@@ -175,9 +175,9 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let input = "collection Test {}";
+        let input = "contract Test {}";
         let expected_output = expect![[
-            r#"{"Ok":[{"nodes":[{"Contract":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
+            r#"{"Ok":[{"nodes":[{"Contract":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"contract","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
         ]];
 
         let output = parse_out_json(input, "");
@@ -188,7 +188,7 @@ mod tests {
     fn test_parse_contract() {
         let input = "contract Test {}";
         let expected_output = expect![[
-            r#"{"Ok":[{"nodes":[{"Contract":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
+            r#"{"Ok":[{"nodes":[{"Contract":{"name":"Test","decorators":[],"items":[]}}]},[{"kind":"contract","namespace":{"kind":"namespace","value":""},"name":"Test","attributes":[]}]]}"#
         ]];
 
         let output = parse_out_json(input, "");
@@ -196,10 +196,10 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_collection_metadata() {
-        let input = "@public collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; ast?: string; publicKey?: PublicKey; @index(publicKey); @index([lastRecordUpdated, desc]); constructor (id: string, code: string) { this.id = id; this.code = code; this.ast = parse(code); if (ctx.publicKey) this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error('invalid owner'); } this.code = code; this.ast = parse(code); } }";
+    fn test_parse_contract_metadata() {
+        let input = "@public contract Contract { id: string; name?: string; lastRecordUpdated?: string; code?: string; ast?: string; publicKey?: PublicKey; @index(publicKey); @index([lastRecordUpdated, desc]); constructor (id: string, code: string) { this.id = id; this.code = code; this.ast = parse(code); if (ctx.publicKey) this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error('invalid owner'); } this.code = code; this.ast = parse(code); } }";
         let expected_output = expect![[
-            r#"[{"kind":"collection","namespace":{"kind":"namespace","value":""},"name":"Collection","attributes":[{"kind":"property","name":"id","type":{"kind":"primitive","value":"string"},"directives":[],"required":true},{"kind":"property","name":"name","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"lastRecordUpdated","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"code","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"ast","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"publicKey","type":{"kind":"publickey"},"directives":[],"required":false},{"kind":"index","fields":[{"direction":"asc","fieldPath":["publicKey"]}]},{"kind":"index","fields":[{"direction":"desc","fieldPath":["lastRecordUpdated"]}]},{"kind":"method","name":"constructor","attributes":[{"kind":"parameter","name":"id","type":{"kind":"primitive","value":"string"},"required":true},{"kind":"parameter","name":"code","type":{"kind":"primitive","value":"string"},"required":true}],"code":"this.id = id; this.code = code; this.ast = parse(code); if (ctx.publicKey) this.publicKey = ctx.publicKey;"},{"kind":"method","name":"updateCode","attributes":[{"kind":"parameter","name":"code","type":{"kind":"primitive","value":"string"},"required":true}],"code":"if (this.publicKey != ctx.publicKey) { throw error('invalid owner'); } this.code = code; this.ast = parse(code);"},{"kind":"directive","name":"public","arguments":[]}]}]"#
+            r#"[{"kind":"contract","namespace":{"kind":"namespace","value":""},"name":"Contract","attributes":[{"kind":"property","name":"id","type":{"kind":"primitive","value":"string"},"directives":[],"required":true},{"kind":"property","name":"name","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"lastRecordUpdated","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"code","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"ast","type":{"kind":"primitive","value":"string"},"directives":[],"required":false},{"kind":"property","name":"publicKey","type":{"kind":"publickey"},"directives":[],"required":false},{"kind":"index","fields":[{"direction":"asc","fieldPath":["publicKey"]}]},{"kind":"index","fields":[{"direction":"desc","fieldPath":["lastRecordUpdated"]}]},{"kind":"method","name":"constructor","attributes":[{"kind":"parameter","name":"id","type":{"kind":"primitive","value":"string"},"required":true},{"kind":"parameter","name":"code","type":{"kind":"primitive","value":"string"},"required":true}],"code":"this.id = id; this.code = code; this.ast = parse(code); if (ctx.publicKey) this.publicKey = ctx.publicKey;"},{"kind":"method","name":"updateCode","attributes":[{"kind":"parameter","name":"code","type":{"kind":"primitive","value":"string"},"required":true}],"code":"if (this.publicKey != ctx.publicKey) { throw error('invalid owner'); } this.code = code; this.ast = parse(code);"},{"kind":"directive","name":"public","arguments":[]}]}]"#
         ]];
 
         let mut program = None::<ast::Program>;
@@ -210,9 +210,9 @@ mod tests {
     }
 
     #[test]
-    fn test_collection() {
+    fn test_contract() {
         let mut program = None::<ast::Program>;
-        let (program, _) = parse("collection Test {}", "", &mut program).unwrap();
+        let (program, _) = parse("contract Test {}", "", &mut program).unwrap();
 
         assert_eq!(program.nodes.len(), 1);
         assert!(
@@ -221,11 +221,11 @@ mod tests {
     }
 
     #[test]
-    fn test_collection_with_fields() {
+    fn test_contract_with_fields() {
         let mut program = None::<ast::Program>;
         let (program, _) = parse(
             "
-            collection Test {
+            contract Test {
                 name: string;
                 age: number;
             }
@@ -240,25 +240,25 @@ mod tests {
             matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 2)
         );
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(contract) => contract,
-            _ => panic!("Expected collection"),
+            _ => panic!("Expected contract"),
         };
 
         assert!(
-            matches!(&collection.items[0], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "name" && *type_ == ast::Type::String && decorators.is_empty())
+            matches!(&contract.items[0], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "name" && *type_ == ast::Type::String && decorators.is_empty())
         );
         assert!(
-            matches!(&collection.items[1], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "age" && *type_ == ast::Type::Number && decorators.is_empty())
+            matches!(&contract.items[1], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "age" && *type_ == ast::Type::Number && decorators.is_empty())
         );
     }
 
     #[test]
-    fn test_collection_with_asc_desc_fields() {
+    fn test_contract_with_asc_desc_fields() {
         let mut program = None::<ast::Program>;
         let (program, _) = parse(
             "
-            collection Test {
+            contract Test {
                 asc: string;
                 desc: string;
             }
@@ -273,25 +273,25 @@ mod tests {
             matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 2)
         );
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(contract) => contract,
-            _ => panic!("Expected collection"),
+            _ => panic!("Expected contract"),
         };
 
         assert!(
-            matches!(&collection.items[0], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "asc" && *type_ == ast::Type::String && decorators.is_empty()),
+            matches!(&contract.items[0], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "asc" && *type_ == ast::Type::String && decorators.is_empty()),
         );
         assert!(
-            matches!(&collection.items[1], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "desc" && *type_ == ast::Type::String && decorators.is_empty()),
+            matches!(&contract.items[1], ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators }) if name == "desc" && *type_ == ast::Type::String && decorators.is_empty()),
         );
     }
 
     #[test]
-    fn test_collection_with_functions() {
+    fn test_contract_with_functions() {
         let mut program = None::<ast::Program>;
         let (program, _) = parse(
             "
-            collection Test {
+            contract Test {
                 function get_age(a: number, b?: string) {
                     return 42;
                 }
@@ -307,13 +307,13 @@ mod tests {
             matches!(&program.nodes[0], ast::RootNode::Contract(ast::Contract { name, decorators, items }) if name == "Test" && decorators.is_empty() && items.len() == 1)
         );
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(contract) => contract,
-            _ => panic!("Expected collection"),
+            _ => panic!("Expected contract"),
         };
 
         assert!(
-            matches!(&collection.items[0], ast::ContractItem::Function(ast::Function {
+            matches!(&contract.items[0], ast::ContractItem::Function(ast::Function {
                 name,
                 decorators,
                 parameters,
@@ -323,7 +323,7 @@ mod tests {
             }) if name == "get_age" && decorators.is_empty() && parameters.len() == 2 && statements.len() == 1 && statements_code == "return 42;" && return_type.is_none())
         );
 
-        let function = match &collection.items[0] {
+        let function = match &contract.items[0] {
             ast::ContractItem::Function(function) => function,
             _ => panic!("Expected function"),
         };
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     fn test_code_from_issue() {
         let code = "
-            collection Account {
+            contract Account {
                 name: string;
                 age?: number;
                 balance: number;
@@ -507,47 +507,47 @@ mod tests {
 
         assert_eq!(program.nodes.len(), 1);
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(contract) => contract,
-            _ => panic!("Expected collection"),
+            _ => panic!("Expected contract"),
         };
 
-        assert_eq!(collection.name, "Account");
-        assert_eq!(collection.items.len(), 6);
+        assert_eq!(contract.name, "Account");
+        assert_eq!(contract.items.len(), 6);
 
         assert!(matches!(
-            &collection.items[0],
+            &contract.items[0],
             ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators })
             if name == "name" && *type_ == ast::Type::String && decorators.is_empty()
         ));
 
         assert!(matches!(
-            &collection.items[1],
+            &contract.items[1],
             ast::ContractItem::Field(ast::Field { name, type_, required: false, decorators })
             if name == "age" && *type_ == ast::Type::Number && decorators.is_empty()
         ));
 
         assert!(matches!(
-            &collection.items[2],
+            &contract.items[2],
             ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators })
             if name == "balance" && *type_ == ast::Type::Number && decorators.is_empty()
         ));
 
         assert!(matches!(
-            &collection.items[3],
+            &contract.items[3],
             ast::ContractItem::Field(ast::Field { name, type_, required: true, decorators })
             if name == "publicKey" && *type_ == ast::Type::String && decorators.is_empty()
         ));
 
         assert!(matches!(
-            &collection.items[4],
+            &contract.items[4],
             ast::ContractItem::Index(ast::Index {
                 fields,
             }) if fields[0].path == ["field"] && fields[0].order == ast::Order::Asc
                 && fields[1].path == ["field2"] && fields[1].order == ast::Order::Asc
         ));
 
-        let function = match &collection.items[5] {
+        let function = match &contract.items[5] {
             ast::ContractItem::Function(f) => f,
             _ => panic!("expected function"),
         };
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     fn test_error_unrecognized_token() {
         let code = "
-            collection test-cities {}
+            contract test-cities {}
         ";
 
         let mut program = None::<ast::Program>;
@@ -644,16 +644,16 @@ mod tests {
         eprintln!("{}", result.as_ref().unwrap_err().message);
         assert_eq!(
             result.unwrap_err().message,
-            r#"Error found at line 2, column 27: Unrecognized token "-". Expected one of: "{"
-collection test-cities {}
-               ^"#,
+            r#"Error found at line 2, column 25: Unrecognized token "-". Expected one of: "{"
+contract test-cities {}
+             ^"#,
         );
     }
 
     #[test]
     fn test_error_invalid_token() {
         let code = "
-            collection ą {}
+            contract ą {}
         ";
 
         let mut program = None::<ast::Program>;
@@ -662,9 +662,9 @@ collection test-cities {}
         eprintln!("{}", result.as_ref().unwrap_err().message);
         assert_eq!(
             result.unwrap_err().message,
-            r#"Error found at line 2, column 23: Invalid token
-collection ą {}
-           ^"#,
+            r#"Error found at line 2, column 21: Invalid token
+contract ą {}
+         ^"#,
         );
     }
 
@@ -689,7 +689,7 @@ function x() {
     #[test]
     fn test_foreign_record_field() {
         let code = "
-            collection test {
+            contract test {
                 account: Account;
             }
         ";
@@ -697,14 +697,14 @@ function x() {
         let mut program = None::<ast::Program>;
         let (program, _) = parse(code, "", &mut program).unwrap();
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(c) => c,
-            _ => panic!("expected collection"),
+            _ => panic!("expected contract"),
         };
 
-        assert_eq!(collection.items.len(), 1);
+        assert_eq!(contract.items.len(), 1);
 
-        let field = match &collection.items[0] {
+        let field = match &contract.items[0] {
             ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
@@ -722,7 +722,7 @@ function x() {
     fn test_array_map_field() {
         let cases = [
             (
-                "collection test { numbers: number[]; }",
+                "contract test { numbers: number[]; }",
                 vec![ast::Field {
                     name: "numbers".to_string(),
                     type_: ast::Type::Array(Box::new(ast::Type::Number)),
@@ -731,7 +731,7 @@ function x() {
                 }],
             ),
             (
-                "collection test { strings: string[]; }",
+                "contract test { strings: string[]; }",
                 vec![ast::Field {
                     name: "strings".to_string(),
                     type_: ast::Type::Array(Box::new(ast::Type::String)),
@@ -740,7 +740,7 @@ function x() {
                 }],
             ),
             (
-                "collection test { numToStr: map<number, string>; }",
+                "contract test { numToStr: map<number, string>; }",
                 vec![ast::Field {
                     name: "numToStr".to_string(),
                     type_: ast::Type::Map(Box::new(ast::Type::Number), Box::new(ast::Type::String)),
@@ -749,7 +749,7 @@ function x() {
                 }],
             ),
             (
-                "collection test { strToNum: map<string, number>; }",
+                "contract test { strToNum: map<string, number>; }",
                 vec![ast::Field {
                     name: "strToNum".to_string(),
                     type_: ast::Type::Map(Box::new(ast::Type::String), Box::new(ast::Type::Number)),
@@ -763,16 +763,16 @@ function x() {
             let mut program = None::<ast::Program>;
             let (program, _) = parse(code, "", &mut program).unwrap();
             assert_eq!(program.nodes.len(), 1);
-            let collection = match &program.nodes[0] {
+            let contract = match &program.nodes[0] {
                 ast::RootNode::Contract(c) => c,
-                _ => panic!("expected collection"),
+                _ => panic!("expected contract"),
             };
-            assert_eq!(collection.items.len(), expected.len());
+            assert_eq!(contract.items.len(), expected.len());
 
             for (i, item) in expected.iter().enumerate() {
                 assert!(
                     matches!(
-                        &collection.items[i],
+                        &contract.items[i],
                         ast::ContractItem::Field(ast::Field {
                             name,
                             type_,
@@ -782,7 +782,7 @@ function x() {
                     ),
                     "expected: {:?}, got: {:?}",
                     item,
-                    collection.items[i]
+                    contract.items[i]
                 );
             }
         }
@@ -792,7 +792,7 @@ function x() {
     fn test_object_field() {
         let cases = [
             (
-                "collection test { person: { name: string; age: number; }; }",
+                "contract test { person: { name: string; age: number; }; }",
                 vec![ast::Field {
                     name: "person".to_string(),
                     type_: ast::Type::Object(vec![
@@ -814,7 +814,7 @@ function x() {
                 }],
             ),
             (
-                "collection test { person: { name?: string; }; }",
+                "contract test { person: { name?: string; }; }",
                 vec![ast::Field {
                     name: "person".to_string(),
                     type_: ast::Type::Object(vec![ast::Field {
@@ -828,7 +828,7 @@ function x() {
                 }],
             ),
             (
-                "collection test { person: { info: { name: string; }; }; }",
+                "contract test { person: { info: { name: string; }; }; }",
                 vec![ast::Field {
                     name: "person".to_string(),
                     type_: ast::Type::Object(vec![ast::Field {
@@ -852,16 +852,16 @@ function x() {
             let mut program = None::<ast::Program>;
             let (program, _) = parse(code, "", &mut program).unwrap();
             assert_eq!(program.nodes.len(), 1);
-            let collection = match &program.nodes[0] {
+            let contract = match &program.nodes[0] {
                 ast::RootNode::Contract(c) => c,
-                _ => panic!("expected collection"),
+                _ => panic!("expected contract"),
             };
-            assert_eq!(collection.items.len(), expected.len());
+            assert_eq!(contract.items.len(), expected.len());
 
             for (i, item) in expected.iter().enumerate() {
                 assert!(
                     matches!(
-                        &collection.items[i],
+                        &contract.items[i],
                         ast::ContractItem::Field(ast::Field {
                             name,
                             type_,
@@ -871,7 +871,7 @@ function x() {
                     ),
                     "expected: {:?}, got: {:?}",
                     item,
-                    collection.items[i]
+                    contract.items[i]
                 );
             }
         }
@@ -880,7 +880,7 @@ function x() {
     #[test]
     fn test_comments() {
         let code = "
-            collection test {
+            contract test {
                 // This is a comment
                 name: string;
 
@@ -899,7 +899,7 @@ function x() {
     #[test]
     fn test_index_subfield() {
         let code = "
-            collection test {
+            contract test {
                 person: {
                     name: string;
                 };
@@ -912,22 +912,22 @@ function x() {
         let (program, _) = parse(code, "", &mut program).unwrap();
         assert_eq!(program.nodes.len(), 1);
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(c) => c,
-            _ => panic!("expected collection"),
+            _ => panic!("expected contract"),
         };
-        assert_eq!(collection.items.len(), 2);
+        assert_eq!(contract.items.len(), 2);
 
         assert!(
             matches!(
-                &collection.items[1],
+                &contract.items[1],
                 ast::ContractItem::Index(ast::Index {
                     fields,
                 }) if fields == &[ast::IndexField { path: vec!["person".to_string(), "name".to_string()], order: ast::Order::Asc }]
             ),
             "expected: {:?}, got: {:?}",
-            &collection.items[1],
-            &collection.items[1]
+            &contract.items[1],
+            &contract.items[1]
         );
     }
 
@@ -935,7 +935,7 @@ function x() {
     fn test_decorators() {
         let code = "
             @public
-            collection Account {
+            contract Account {
                 @read
                 owner: PublicKey;
 
@@ -948,17 +948,17 @@ function x() {
         let (program, _) = parse(code, "", &mut program).unwrap();
         assert_eq!(program.nodes.len(), 1);
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(c) => c,
-            _ => panic!("expected collection"),
+            _ => panic!("expected contract"),
         };
 
-        assert_eq!(collection.decorators.len(), 1);
-        assert_eq!(collection.decorators[0].name, "public");
+        assert_eq!(contract.decorators.len(), 1);
+        assert_eq!(contract.decorators[0].name, "public");
 
-        assert_eq!(collection.items.len(), 2);
+        assert_eq!(contract.items.len(), 2);
 
-        let field = match &collection.items[0] {
+        let field = match &contract.items[0] {
             ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
@@ -966,7 +966,7 @@ function x() {
         assert_eq!(field.decorators.len(), 1);
         assert_eq!(field.decorators[0].name, "read");
 
-        let function = match &collection.items[1] {
+        let function = match &contract.items[1] {
             ast::ContractItem::Function(f) => f,
             _ => panic!("expected function"),
         };
@@ -983,7 +983,7 @@ function x() {
     #[test]
     fn test_foreign_record_array() {
         let code = "
-            collection test {
+            contract test {
                 people: Person[];
             }
         ";
@@ -992,14 +992,14 @@ function x() {
         let (program, _) = parse(code, "", &mut program).unwrap();
         assert_eq!(program.nodes.len(), 1);
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(c) => c,
-            _ => panic!("expected collection"),
+            _ => panic!("expected contract"),
         };
 
-        assert_eq!(collection.items.len(), 1);
+        assert_eq!(contract.items.len(), 1);
 
-        let field = match &collection.items[0] {
+        let field = match &contract.items[0] {
             ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
@@ -1081,7 +1081,7 @@ function x() {
     #[test]
     fn test_object() {
         let code = r#"
-            collection Test {
+            contract Test {
                 field: { a?: number; };
 
                 constructor () {
@@ -1094,14 +1094,14 @@ function x() {
         let (program, _) = parse(code, "", &mut program).unwrap();
         assert_eq!(program.nodes.len(), 1);
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(c) => c,
-            _ => panic!("expected collection"),
+            _ => panic!("expected contract"),
         };
 
-        assert_eq!(collection.items.len(), 2);
+        assert_eq!(contract.items.len(), 2);
 
-        let field = match &collection.items[0] {
+        let field = match &contract.items[0] {
             ast::ContractItem::Field(f) => f,
             _ => panic!("expected field"),
         };
@@ -1117,7 +1117,7 @@ function x() {
             }])
         );
 
-        let function = match &collection.items[1] {
+        let function = match &contract.items[1] {
             ast::ContractItem::Function(f) => f,
             _ => panic!("expected function"),
         };
@@ -1142,7 +1142,7 @@ function x() {
     #[test]
     fn test_public_key_array_decl() {
         let code = r#"
-            collection PublicKeyArrayDemo {
+            contract PublicKeyArrayDemo {
               publicKeys: PublicKey[];
 
               constructor () {
@@ -1157,14 +1157,14 @@ function x() {
         let (program, _) = parse(code, "", &mut program).unwrap();
         assert_eq!(program.nodes.len(), 1);
 
-        let collection = match &program.nodes[0] {
+        let contract = match &program.nodes[0] {
             ast::RootNode::Contract(c) => c,
-            _ => panic!("expected collection"),
+            _ => panic!("expected contract"),
         };
 
-        assert_eq!(collection.items.len(), 2);
+        assert_eq!(contract.items.len(), 2);
 
-        let field = match &collection.items[0] {
+        let field = match &contract.items[0] {
             ast::ContractItem::Field(f) => f,
             _ => panic!("expected publicKeys"),
         };
@@ -1176,9 +1176,9 @@ function x() {
         );
     }
 
-    /// Tests that collections from the filesystem directory 'test-collections' parse without an error
+    /// Tests that contracts from the filesystem directory 'test-collections' parse without an error
     #[test]
-    fn test_fs_collections() {
+    fn test_fs_contracts() {
         use std::path::Path;
 
         let dir = Path::new("test-collections");
@@ -1199,7 +1199,7 @@ function x() {
             let mut program = None::<ast::Program>;
             let result = parse(&code, "", &mut program);
             if let Err(err) = result {
-                eprintln!("Error parsing collection: {}", path.display());
+                eprintln!("Error parsing contract: {}", path.display());
                 eprintln!("{}", err.message);
                 results.push(err);
             }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -517,7 +517,7 @@ pub(crate) fn validate_value<'a>(
                 })
             }
         }
-        stableast::Type::ForeignRecord(stableast::ForeignRecord { collection: _ }) => {
+        stableast::Type::ForeignRecord(stableast::ForeignRecord { contract: _ }) => {
             if let Value::Map(map) = value {
                 if let Some(extra_field) = map.keys().find(|k| *k != "id") {
                     let mut path = path.clone();
@@ -562,14 +562,14 @@ pub(crate) fn validate_value<'a>(
 }
 
 pub(crate) fn validate_set<'a>(
-    collection: &'a stableast::Collection,
+    contract: &'a stableast::Contract,
     data: &'a HashMap<String, Value>,
 ) -> Result<(), ValidationError<'a>> {
-    let fields = collection
+    let fields = contract
         .attributes
         .iter()
         .filter_map(|item| {
-            if let stableast::CollectionAttribute::Property(prop) = item {
+            if let stableast::ContractAttribute::Property(prop) = item {
                 Some(prop)
             } else {
                 None
@@ -611,11 +611,11 @@ mod tests {
 
     #[test]
     fn test_validate_set() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
             attributes: vec![
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "name".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::String,
@@ -623,7 +623,7 @@ mod tests {
                     directives: vec![],
                     required: true,
                 }),
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "age".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::Number,
@@ -639,15 +639,15 @@ mod tests {
             ("age".to_string(), Value::Number(30.0)),
         ]);
 
-        assert!(validate_set(&collection, &data).is_ok());
+        assert!(validate_set(&contract, &data).is_ok());
     }
 
     #[test]
     fn test_validate_set_array() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Array(stableast::Array {
@@ -669,15 +669,15 @@ mod tests {
             ]),
         )]);
 
-        assert!(validate_set(&collection, &data).is_ok());
+        assert!(validate_set(&contract, &data).is_ok());
     }
 
     #[test]
     fn test_validate_set_array_invalid_array_value() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Array(stableast::Array {
@@ -696,7 +696,7 @@ mod tests {
             Value::Array(vec![Value::String("tag1".to_string()), Value::Number(2.0)]),
         )]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         assert_eq!(
@@ -712,10 +712,10 @@ mod tests {
 
     #[test]
     fn test_validate_map() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Map(stableast::Map {
@@ -740,15 +740,15 @@ mod tests {
             ])),
         )]);
 
-        assert!(validate_set(&collection, &data).is_ok());
+        assert!(validate_set(&contract, &data).is_ok());
     }
 
     #[test]
     fn test_validate_nested_map() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Map(stableast::Map {
@@ -790,15 +790,15 @@ mod tests {
             ])),
         )]);
 
-        assert!(validate_set(&collection, &data).is_ok());
+        assert!(validate_set(&contract, &data).is_ok());
     }
 
     #[test]
     fn test_validate_map_number_key() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Map(stableast::Map {
@@ -823,15 +823,15 @@ mod tests {
             ])),
         )]);
 
-        assert!(validate_set(&collection, &data).is_ok());
+        assert!(validate_set(&contract, &data).is_ok());
     }
 
     #[test]
     fn test_validate_map_number_key_invalid() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Map(stableast::Map {
@@ -856,7 +856,7 @@ mod tests {
             ])),
         )]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         assert_eq!(
@@ -872,10 +872,10 @@ mod tests {
 
     #[test]
     fn test_validate_map_invalid_key() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "tags".into(),
                     type_: stableast::Type::Map(stableast::Map {
@@ -900,7 +900,7 @@ mod tests {
             ])),
         )]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         assert_eq!(
@@ -918,10 +918,10 @@ mod tests {
     fn test_validate_object() {
         let cases = [
             (
-                stableast::Collection {
+                stableast::Contract {
                     namespace: stableast::Namespace { value: "ns".into() },
                     name: "users".into(),
-                    attributes: vec![stableast::CollectionAttribute::Property(
+                    attributes: vec![stableast::ContractAttribute::Property(
                         stableast::Property {
                             name: "info".into(),
                             type_: stableast::Type::Object(stableast::Object {
@@ -947,10 +947,10 @@ mod tests {
                 )]),
             ),
             (
-                stableast::Collection {
+                stableast::Contract {
                     namespace: stableast::Namespace { value: "ns".into() },
                     name: "users".into(),
-                    attributes: vec![stableast::CollectionAttribute::Property(
+                    attributes: vec![stableast::ContractAttribute::Property(
                         stableast::Property {
                             name: "info".into(),
                             type_: stableast::Type::Object(stableast::Object {
@@ -970,10 +970,10 @@ mod tests {
                 HashMap::from([("info".to_string(), Value::Map(HashMap::from([])))]),
             ),
             (
-                stableast::Collection {
+                stableast::Contract {
                     namespace: stableast::Namespace { value: "ns".into() },
                     name: "users".into(),
-                    attributes: vec![stableast::CollectionAttribute::Property(
+                    attributes: vec![stableast::ContractAttribute::Property(
                         stableast::Property {
                             name: "info".into(),
                             type_: stableast::Type::Object(stableast::Object {
@@ -994,9 +994,9 @@ mod tests {
             ),
         ];
 
-        for (collection, data) in cases.into_iter() {
+        for (contract, data) in cases.into_iter() {
             assert!(
-                validate_set(&collection, &data).is_ok(),
+                validate_set(&contract, &data).is_ok(),
                 "failed to validate: {:?}",
                 data
             );
@@ -1005,10 +1005,10 @@ mod tests {
 
     #[test]
     fn test_validate_object_missing_field() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "info".into(),
                     type_: stableast::Type::Object(stableast::Object {
@@ -1028,7 +1028,7 @@ mod tests {
 
         let data = HashMap::from([("info".to_string(), Value::Map(HashMap::from([])))]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         assert_eq!(
@@ -1041,10 +1041,10 @@ mod tests {
 
     #[test]
     fn test_validate_object_extra_field() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "info".into(),
                     type_: stableast::Type::Object(stableast::Object {
@@ -1070,7 +1070,7 @@ mod tests {
             ])),
         )]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         let error = result.unwrap_err();
@@ -1084,11 +1084,11 @@ mod tests {
 
     #[test]
     fn test_validate_set_missing_required_field() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
             attributes: vec![
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "name".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::String,
@@ -1096,7 +1096,7 @@ mod tests {
                     required: true,
                     directives: vec![],
                 }),
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "age".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::Number,
@@ -1109,7 +1109,7 @@ mod tests {
 
         let data = HashMap::from([("age".to_string(), Value::Number(30.0))]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         let error = result.unwrap_err();
@@ -1123,11 +1123,11 @@ mod tests {
 
     #[test]
     fn test_validate_set_invalid_type() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
             attributes: vec![
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "name".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::String,
@@ -1135,7 +1135,7 @@ mod tests {
                     required: true,
                     directives: vec![],
                 }),
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "age".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::Number,
@@ -1151,7 +1151,7 @@ mod tests {
             ("age".to_string(), Value::String("30".to_string())),
         ]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         let error = result.unwrap_err();
@@ -1168,11 +1168,11 @@ mod tests {
 
     #[test]
     fn test_validate_set_extra_field() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
             attributes: vec![
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "name".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::String,
@@ -1180,7 +1180,7 @@ mod tests {
                     required: true,
                     directives: vec![],
                 }),
-                stableast::CollectionAttribute::Property(stableast::Property {
+                stableast::ContractAttribute::Property(stableast::Property {
                     name: "age".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
                         value: stableast::PrimitiveType::Number,
@@ -1197,7 +1197,7 @@ mod tests {
             ("extra".to_string(), Value::String("extra".to_string())),
         ]);
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert!(result.is_err());
 
         let error = result.unwrap_err();
@@ -1211,10 +1211,10 @@ mod tests {
 
     #[test]
     fn test_validate_boolean() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
             name: "users".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "is_admin".into(),
                     type_: stableast::Type::Primitive(stableast::Primitive {
@@ -1227,20 +1227,20 @@ mod tests {
         };
 
         assert!(validate_set(
-            &collection,
+            &contract,
             &HashMap::from([("is_admin".to_string(), Value::Boolean(true))])
         )
         .is_ok());
 
         assert!(validate_set(
-            &collection,
+            &contract,
             &HashMap::from([("is_admin".to_string(), Value::Boolean(false))])
         )
         .is_ok());
 
         assert_eq!(
             validate_set(
-                &collection,
+                &contract,
                 &HashMap::from([("is_admin".to_string(), Value::Number(1.0))])
             ),
             Err(ValidationError::InvalidType {
@@ -1256,10 +1256,10 @@ mod tests {
         ($name:ident, $data:expr, $expected:expr) => {
             #[test]
             fn $name() {
-                let collection = stableast::Collection {
+                let contract = stableast::Contract {
                     namespace: stableast::Namespace { value: "ns".into() },
                     name: "users".into(),
-                    attributes: vec![stableast::CollectionAttribute::Property(
+                    attributes: vec![stableast::ContractAttribute::Property(
                         stableast::Property {
                             name: "public_key".into(),
                             type_: stableast::Type::PublicKey(stableast::PublicKey {}),
@@ -1269,7 +1269,7 @@ mod tests {
                     )],
                 };
                 let data = $data;
-                let result = validate_set(&collection, &data);
+                let result = validate_set(&contract, &data);
 
                 assert_eq!(result, $expected, "{:?}", result);
             }
@@ -1492,10 +1492,10 @@ mod tests {
 
     #[test]
     fn test_validate_public_key_optional() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
-            name: "Collection".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            name: "Contract".into(),
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "public_key".into(),
                     type_: stableast::Type::PublicKey(stableast::PublicKey {}),
@@ -1507,7 +1507,7 @@ mod tests {
 
         let data = HashMap::new();
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert_eq!(result, Ok(()));
     }
 
@@ -1515,14 +1515,14 @@ mod tests {
         ($name:ident, $data:expr, $expected:expr) => {
             #[test]
             fn $name() {
-                let collection = stableast::Collection {
+                let contract = stableast::Contract {
                     namespace: stableast::Namespace { value: "ns".into() },
-                    name: "Collection".into(),
-                    attributes: vec![stableast::CollectionAttribute::Property(
+                    name: "Contract".into(),
+                    attributes: vec![stableast::ContractAttribute::Property(
                         stableast::Property {
                             name: "foreign_record".into(),
                             type_: stableast::Type::ForeignRecord(stableast::ForeignRecord {
-                                collection: "ForeignCollection".into(),
+                                contract: "ForeignContract".into(),
                             }),
                             required: true,
                             directives: vec![],
@@ -1531,7 +1531,7 @@ mod tests {
                 };
 
                 let data = $data;
-                let result = validate_set(&collection, &data);
+                let result = validate_set(&contract, &data);
                 assert_eq!(result, $expected);
             }
         };
@@ -1579,14 +1579,14 @@ mod tests {
 
     #[test]
     fn test_validate_foreign_record_optional() {
-        let collection = stableast::Collection {
+        let contract = stableast::Contract {
             namespace: stableast::Namespace { value: "ns".into() },
-            name: "Collection".into(),
-            attributes: vec![stableast::CollectionAttribute::Property(
+            name: "Contract".into(),
+            attributes: vec![stableast::ContractAttribute::Property(
                 stableast::Property {
                     name: "foreign_record".into(),
                     type_: stableast::Type::ForeignRecord(stableast::ForeignRecord {
-                        collection: "ForeignCollection".into(),
+                        contract: "ForeignContract".into(),
                     }),
                     required: false,
                     directives: vec![],
@@ -1596,17 +1596,17 @@ mod tests {
 
         let data = HashMap::new();
 
-        let result = validate_set(&collection, &data);
+        let result = validate_set(&contract, &data);
         assert_eq!(result, Ok(()));
     }
     macro_rules! test_validate_bytes {
         ($name:ident, $data:expr, $expected:expr) => {
             #[test]
             fn $name() {
-                let collection = stableast::Collection {
+                let contract = stableast::Contract {
                     namespace: stableast::Namespace { value: "ns".into() },
-                    name: "Collection".into(),
-                    attributes: vec![stableast::CollectionAttribute::Property(
+                    name: "Contract".into(),
+                    attributes: vec![stableast::ContractAttribute::Property(
                         stableast::Property {
                             name: "bytes".into(),
                             type_: stableast::Type::Primitive(stableast::Primitive {
@@ -1619,7 +1619,7 @@ mod tests {
                 };
 
                 let data = $data;
-                let result = validate_set(&collection, &data);
+                let result = validate_set(&contract, &data);
                 assert_eq!(result, $expected);
             }
         };

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -798,8 +798,8 @@ fn call_auth_delegate(use_correct_pk: bool) -> Result<(), Box<dyn std::error::Er
                 [
                     (
                         "user",
-                        CollectionReference {
-                            collection: "User",
+                        ContractReference {
+                            contract: "User",
                         },
                     ),
                 ]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -163,10 +163,110 @@ fn call_public_collection() {
 }
 
 #[test]
+fn call_public_contract() {
+    let code = r#"
+        @public
+        contract Account {
+            id: string;
+            name: string;
+
+            setName(name: string) {
+                this.name = name;
+            }
+        }
+    "#;
+
+    let (abi, output) = run(
+        code,
+        "Account",
+        "setName",
+        serde_json::json!({
+            "id": "",
+            "name": "",
+        }),
+        vec![serde_json::json!("test")],
+        None,
+        HashMap::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.this(&abi).unwrap(),
+        abi::Value::StructValue(vec![
+            ("id".to_owned(), abi::Value::String("".to_owned())),
+            ("name".to_owned(), abi::Value::String("test".to_owned())),
+        ])
+    );
+
+    consistency_checks!(
+        output,
+        abi,
+        hashes:
+            expect![[r#"
+                []
+            "#]],
+        dependencies:
+            expect![[r#"
+                []
+            "#]]
+    );
+}
+
+#[test]
 fn call_any_call_collection() {
     let code = r#"
         @call
         collection Account {
+            id: string;
+            name: string;
+
+            setName(name: string) {
+                this.name = name;
+            }
+        }
+    "#;
+
+    let (abi, output) = run(
+        code,
+        "Account",
+        "setName",
+        serde_json::json!({
+            "id": "",
+            "name": "",
+        }),
+        vec![serde_json::json!("test")],
+        None,
+        HashMap::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.this(&abi).unwrap(),
+        abi::Value::StructValue(vec![
+            ("id".to_owned(), abi::Value::String("".to_owned())),
+            ("name".to_owned(), abi::Value::String("test".to_owned())),
+        ])
+    );
+
+    consistency_checks!(
+        output,
+        abi,
+        hashes:
+            expect![[r#"
+                []
+            "#]],
+        dependencies:
+            expect![[r#"
+                []
+            "#]]
+    );
+}
+
+#[test]
+fn call_any_call_contract() {
+    let code = r#"
+        @call
+        contract Account {
             id: string;
             name: string;
 

--- a/tests/src/push.rs
+++ b/tests/src/push.rs
@@ -6,7 +6,7 @@ fn run_push(
 ) -> Result<(abi::Value, abi::Value), error::Error> {
     let code = r#"
         @public
-        collection Account {
+        contract Account {
             id: string;
             arr: number[];
             result: number;
@@ -53,7 +53,7 @@ fn run_push17(
 ) -> Result<(abi::Value, abi::Value), error::Error> {
     let code = r#"
         @public
-        collection Account {
+        contract Account {
             id: string;
             arr: number[];
             result: number;

--- a/tests/src/slice.rs
+++ b/tests/src/slice.rs
@@ -8,7 +8,7 @@ fn run_slice(
 ) -> Result<abi::Value, error::Error> {
     let code = r#"
         @public
-        collection Account {
+        contract Account {
             id: string;
             arr: number[];
             sliced: number[];

--- a/tests/src/splice.rs
+++ b/tests/src/splice.rs
@@ -8,7 +8,7 @@ fn run_splice(
 ) -> Result<(abi::Value, abi::Value), error::Error> {
     let code = r#"
         @public
-        collection Account {
+        contract Account {
             id: string;
             arr: number[];
             ret: number[];

--- a/tests/src/string.rs
+++ b/tests/src/string.rs
@@ -3,7 +3,7 @@ use super::*;
 fn run_fn(f: &str, result: &str, s1: &str, s2: &str) -> Result<abi::Value, error::Error> {
     let code = r#"
         @public
-        collection Account {
+        contract Account {
             result_bool: boolean;
             result_i32: i32;
 

--- a/tests/src/unshift.rs
+++ b/tests/src/unshift.rs
@@ -7,7 +7,7 @@ fn run_unshift(
 ) -> Result<(abi::Value, abi::Value), error::Error> {
     let code = r#"
         @public
-        collection Account {
+        contract Account {
             id: string;
             arr: number[];
             len: u32;

--- a/wasm-api/example.js
+++ b/wasm-api/example.js
@@ -18,11 +18,11 @@ function justMain() {
   return output;
 }
 
-function withCollection() {
+function withContracts() {
   let program = pkg.compile(
     // If the log was absent, we wouldn't get `id` in the output,
     // because the compiler optimizes it away for performance
-    "@public collection Account { id: string; function main() { log(this.id); } }",
+    "@public contract Account { id: string; function main() { log(this.id); } }",
     "Account",
     "main"
   );
@@ -48,4 +48,4 @@ function report(output, hasThis) {
 }
 
 console.log(report(justMain(), false));
-console.log(report(withCollection(), true));
+console.log(report(withContract(), true));

--- a/wasm-api/src/lib.rs
+++ b/wasm-api/src/lib.rs
@@ -14,14 +14,14 @@ pub struct Program {
 #[wasm_bindgen]
 pub fn compile(
     code: String,
-    collection_name: Option<String>,
+    contract_name: Option<String>,
     fn_name: &str,
 ) -> Result<Program, JsError> {
     let program = polylang::parse_program(&code)?;
     let (miden_code, mut abi) =
-        polylang::compiler::compile(program, collection_name.as_deref(), fn_name)?;
+        polylang::compiler::compile(program, contract_name.as_deref(), fn_name)?;
 
-    if collection_name.is_none() {
+    if contract_name.is_none() {
         abi.this_type = Some(abi::Type::Struct(abi::Struct {
             name: "Empty".to_string(),
             fields: Vec::new(),


### PR DESCRIPTION
Changes:
  - added alias `contract` for `collection` in parser-generator grammar.
  - added parser test for `contract`.
  - added alias `contract` for `collection` in lexer + test.
  - added test in `polylang` tests.