### PR TITLE
ENG-1204: Update docs - make `@public` default for contracts 

### DIFF
--- a/site/pages/docs/getting-started/polylang-cli.mdx
+++ b/site/pages/docs/getting-started/polylang-cli.mdx
@@ -11,7 +11,6 @@ This assumes that you have cloned the repository locally, and built it as descri
 Suppose we have a contract representing an account: 
 
 ```typescript
-@public
 contract Account {
     id: string;
     name: string;
@@ -36,7 +35,7 @@ We wish to change the value of the `name` field from "John" to "Tom" by invoking
 We can compile and run this contract using the `Polylang` CLI as explained next:
 
 ```bash
- $ cargo run --bin compile -- contract:Account function:setName <<< '@public contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }' \
+ $ cargo run --bin compile -- contract:Account function:setName <<< 'contract Account { id: string; name: string; function setName(newName: string) { this.name = newName; } }' \
   | cargo run -p miden-run -- \
     --this-json '{ "id": "id1", "name": "John" }' \
     --advice-tape-json '["Tom"]'

--- a/site/pages/docs/getting-started/polylang-lib.mdx
+++ b/site/pages/docs/getting-started/polylang-lib.mdx
@@ -161,7 +161,6 @@ use std::{collections::HashMap, io::Write};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the `Account` contract
     let contract = r#"
-      @public
       contract Account {
           id: string;
           name: string;

--- a/site/pages/docs/index.mdx
+++ b/site/pages/docs/index.mdx
@@ -22,7 +22,6 @@ Using `Polylang`, you can define contract fields, and add methods (functions ass
 An example of a typical smart contract in `Polylang` is:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -51,8 +50,6 @@ The code above defines a smart contract called `Person` which defines a set of f
     * the `id` field which uniquely identifies a "record" of this contract
     * a `name` field for storing the name of the person 
     * an `age` field for storing the age of the person
-
-Note the `@public` directive - this indicates that this is a [public](/docs/language-features/permissions) contract whose data and functions can be accessed by everyone. Read more in the [permissions](/docs/language-features/permissions) section.
 
 Like other smart contract languages, `Polylang` allows the updating of a contract's state by calling functions/methods on the contract.
 In the contract above, we have defined a couple of functions that can update the `name` and `age` fields of the contract.

--- a/site/pages/docs/language-features/bindings.mdx
+++ b/site/pages/docs/language-features/bindings.mdx
@@ -22,7 +22,6 @@ Each binding must have an initial value assigned to it. Unitialized bindings are
 Example:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;

--- a/site/pages/docs/language-features/constructors.mdx
+++ b/site/pages/docs/language-features/constructors.mdx
@@ -12,7 +12,6 @@ refer to the [simplified grammar](general-structure).
 For example, suppose we have the following contract:
 
 ```typescript
-@public 
 contract Person {
     id: string;
     name: string;
@@ -36,7 +35,6 @@ the constructor is invoked, passed these values, and the fields for this record 
 The constructor can take fewer arguments than the number of fields in the contract:
 
 ```typescript
-@public 
 contract Person {
     id: string;
     name: string;

--- a/site/pages/docs/language-features/context.mdx
+++ b/site/pages/docs/language-features/context.mdx
@@ -9,7 +9,6 @@ The context object (accessed via the `ctx` object) is a special value that holds
 Suppose we have this contract:
 
 ```typescript
-@public
 contract User {
     id: string;
     name: string;
@@ -42,8 +41,7 @@ For example:
 
 ```bash
 $ cargo run --bin compile -- contract:Account function:setName <<< \
-'@public
- contract User {
+'contract User {
      id: string;
      name: string;
      publicKey: PublicKey;

--- a/site/pages/docs/language-features/control-flow.mdx
+++ b/site/pages/docs/language-features/control-flow.mdx
@@ -13,7 +13,6 @@ Conditional branching is provided by the `if-else` construct. The `else` part is
 A simple example:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -39,7 +38,6 @@ contract Person {
 Note that we cannot chain `if-else`. For instance, the following code is **not** valid:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -69,7 +67,6 @@ Instead, what you can do is to nest them like so:
 
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -108,7 +105,6 @@ contract Person {
 We also have `TypeScript` like `for` loops. See the `incrementAgeMagically` function below:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -134,7 +130,6 @@ contract Person {
 The `while` loop again functions like the `while` loop in C-like languages:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;

--- a/site/pages/docs/language-features/errors.mdx
+++ b/site/pages/docs/language-features/errors.mdx
@@ -23,7 +23,6 @@ The semantics is to abort the function call immediately with the given error mes
 Example:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;

--- a/site/pages/docs/language-features/fields.mdx
+++ b/site/pages/docs/language-features/fields.mdx
@@ -20,7 +20,6 @@ restriction may be lifted in the future.
 By default, all fields in the contract are required. Required fields are usual field declarations. For instance:
 
 ```typescript
-@public
 contract Person {
     name: string;
     age: number;
@@ -36,7 +35,6 @@ contract Person {
 In addition, `Polylang` also allows fields to be declared as optional. This is done by adding a `?` to the field name:
 
 ```typescript
-@public
 contract Employee {
     employed?: boolean;
     balanceDetails?: number;
@@ -50,7 +48,6 @@ contract Employee {
 Field declarations can also be nested. This is useful when the field itself is of composite nature (meaning that the sub-fields within this field are all related in some sense). For example:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -63,7 +60,6 @@ contract Person {
     ...
  }
 
-@public
 contract Country {
     id: string;
     name: string;

--- a/site/pages/docs/language-features/fieldtypes.mdx
+++ b/site/pages/docs/language-features/fieldtypes.mdx
@@ -25,7 +25,6 @@ import { Callout } from 'nextra/components'
 Example:
 
 ```typescript
-@public 
 contract Person {
     id: string;
     name: string;
@@ -46,7 +45,6 @@ This key is used in contracts to enforce a means of [Access Control](https://en.
 Example:
 
 ```typescript
-@public
 contract User {
     id: string;
     name: string;
@@ -71,15 +69,13 @@ For the `ctx.publicKey` part, please refer to the page on [Context](context).
 Later, in the `setName` function (also note the use of the optional `function` keyword), we can check the public key of the user invoking the function against the public key which was used 
 at record creation time, and allow the operation only if they match. 
 
-Note all that this check overrides the loose controls afforded by the `@public` directive by providing fine-grained checks over data updates. See the section on [permissions](permissions) for more
-details on both permissions and the various available directives.
+This check provides fine-grained checks over data updates. See the section on [permissions](permissions) for more details on permissions.
 
 ## Contract Types
 
 A contract type is simply a reference to a `Polybase` contract. Consider the following example:
 
 ```typescript
-@public
 contract Employee {
     id: string;
     name: string;
@@ -98,7 +94,6 @@ contract Employee {
 The `company` field if of type `Company`, which is a contract declared as follows:
 
 ```typescript
-@public
 contract Company {
     id: string;
     name: string;
@@ -124,7 +119,6 @@ in array declarations. Only the following `Polylang` types are permitted:
 Example:
 
 ```typescript
-@public
 contract Bank {
     id: string;
     accId: string;
@@ -133,7 +127,6 @@ contract Bank {
     ...
   }
 
-@public
 contract Account {
     id: string;
     name: string;
@@ -152,7 +145,6 @@ valid `Polylang` type.
 Example:
 
 ```typescript
-@public
 contract Bank {
     id: string;
     accId: string;
@@ -161,7 +153,6 @@ contract Bank {
     ...
   }
 
-@public
 contract Account {
     id: string;
     name: string;

--- a/site/pages/docs/language-features/functions.mdx
+++ b/site/pages/docs/language-features/functions.mdx
@@ -16,7 +16,6 @@ interacting with other contracts and records et al.
 Field values of records can only be updated via functions. Consider the following contract, for instance:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -45,7 +44,6 @@ The `setName` and `setAge` functions can be used to update the values for the `n
 You can have custom validation logic inside functions. In the following example, we check that account we're transferring money from has sufficient funds to carry out that operation:
 
 ```typescript
-@public
 contract Account {
     id; string;
     balance: number;
@@ -72,7 +70,6 @@ contract Account {
 We can also provide tighter checks on *who* can modify the record. Taking the same `Account` contract as above, we modify like so:
 
 ```typescript
-@public
 contract Account {
     id; string;
     balance: number;
@@ -113,7 +110,6 @@ can be named anything, but by convention, such a deletion function is called `de
 For example (building on the same contract):
 
 ```typescript
-@public
 contract Account {
     id; string;
     balance: number;

--- a/site/pages/docs/language-features/general-structure.mdx
+++ b/site/pages/docs/language-features/general-structure.mdx
@@ -32,7 +32,7 @@ where each contract consists of field declarations, a constructor declaration, a
 
 ```yaml
 ContractDeclaration:
-    [`@public`]
+    [(one of)`@public` `@private`]
     `contract` ContractName ContractBody
 
 ContractName:

--- a/site/pages/docs/language-features/lexical-structure.mdx
+++ b/site/pages/docs/language-features/lexical-structure.mdx
@@ -11,7 +11,6 @@ import { Callout } from 'nextra/components'
 `Polylang` supports both singl-line comments using `//` extending to the end of the line:
 
 ```typescript
-@public
 contract Computer {
     id: string;
     // the model for this computer
@@ -28,7 +27,6 @@ contract Computer {
 as well as multi-line comments using `/* ... */`:
 
 ```typescript
-@public
 contract Computer {
     id: string;
     // the model for this computer

--- a/site/pages/docs/language-features/permissions.mdx
+++ b/site/pages/docs/language-features/permissions.mdx
@@ -166,7 +166,7 @@ In the example above, no one can read `Person` data, but anyone can invoke the f
 
 ### @private 
 
-This directive is the most restrictive of all, allowing no one (including the creator of the `contract` to read from or write to the `contract` post creation). This directive can only be applied on contracts.
+This directive is the most restrictive of all, allowing no one (including the creator of the `contract`) to read from or write to the `contract` post creation. This directive can only be applied on contracts.
 
 For example:
 

--- a/site/pages/docs/language-features/permissions.mdx
+++ b/site/pages/docs/language-features/permissions.mdx
@@ -7,11 +7,10 @@ title: Declarative Permissions
 import { Callout } from 'nextra/components'
 
 <Callout type="info" emoji="⚠️️">
-  By default, all contracts are **fully private** - no one (including the creator of the contract) can read from or write to the contract. In this sense, the permissions modes specified here
-  represent varying forms of relaxation of this restriction.
+  By default, all contracts are **fully public** . This is semantically equivalent to using the `@public` directive.
 </Callout>
 
-`Polylang` controls access (read/write) to data in contracts through its permissions model.  This is achieved via the following directives - `@public`, `@read`, `@call`, and `@delegate`, 
+`Polylang` controls access (read/write) to data in contracts through its permissions model.  This is achieved via the following directives - `@public` (default), `@private`, `@read`, `@call`, and `@delegate`, 
 as well as secondary methods such as checking authorization (using a public key, for instance).
 
 `Polylang` Access Control is best understood in terms of what the user is allowed to do (or not do). This leads to the following permission modes:
@@ -28,16 +27,36 @@ Each of these modes is described in detail in the following sections.
 ## Allow all
 
 This is the least constrained mode of access to contracts data. This mode allows anyone to read from and write to (i.e., call `Polylang` functions which modify the record data) contracts in varying levels of granularity 
-using directives.
+using directives. 
+
+This is the default mode of operation. 
+
+The following are equivalent:
+
+```typescript
+contract MyContract {
+    ...
+}
+```
+
+and 
+
+```typescript
+@public
+contract MyContact {
+    ...
+}
+```
 
 ### @read 
 
-This directive allows anyone to read contract data, but not to write data (invoke functions). Unlike `@public`, this directive can be applied to both contracts as well as to a specific field (which must be of type `PublicKey`).
+This directive allows anyone to read contract data, but not to write data (invoke functions). This directive can be applied to both contracts as well as to a specific field (which must be of type `PublicKey`).
 
 To signify read permission on the overall contract:
 
 ```typescript
 @read
+@private
 contract Person {
     id: string;
     name: string;
@@ -63,11 +82,12 @@ contract Person {
 }
 ```
 
-In this case, anyone can read `Person` data, but no one (including the user who created the `Person` contract) can invoke the `setName`, `setAge`, and `del` functions.
+In this case, anyone can read `Person` data, but no one (including the user who created the `Person` contract) can invoke the `setName`, `setAge`, and `del` functions (since the contract is marked `@private`).
 
-If we wish to enforce a stronger constraint that **only** the creator of `Person` contract be allowed to read the contract, we can modify the contract like so:
+If we wish to enforce a stronger constraint that **only** the creator of the `Person` contract be allowed to read the contract, we can modify the contract like so:
 
 ```typescript
+@private
 contract Person {
     id: string;
     name: string;
@@ -97,11 +117,11 @@ contract Person {
 }
 ```
 
-Since the contract above is *not* marked as `@public`, no one other than the creator of the contract, i.e., the user whose public key matches the public key stored in the `creator` field can read the contract data.
+Since the contract above is marked as `@private`, no one other than the creator of the contract, i.e., the user whose public key matches the public key stored in the `creator` field can read the contract data.
 
 ### @call 
 
-This directive allows anyone to invoke functions on the contract record, but not read data from the contract. This directive may be applied on contracts or on individual functions.
+This directive allows anyone to invoke functions on the contract record (if the contract is marked `@private`), but not read data from the contract. This directive may be applied on contracts or on individual functions.
 
 We will consider both cases using the same example. 
 
@@ -109,6 +129,7 @@ Consider the following contract:
 
 ```typescript
 @call
+@private
 contract Person {
     id: string;
     name: string;
@@ -143,14 +164,14 @@ contract Person {
 
 In the example above, no one can read `Person` data, but anyone can invoke the functions `setName` and `setAge`, but **not** the `del` function (since it has a `@call` directive on it, which overrides the directive on the contract).
 
-### @public 
+### @private 
 
-This directive is the most permissive of all, and allows anyone to read and write the contract data. This directive can only be applied on contracts. In essence, `@public` is like a combination of both `@read` and `@call`.
+This directive is the most restrictive of all, allowing no one (including the creator of the `contract` to read from or write to the `contract` post creation). This directive can only be applied on contracts.
 
 For example:
 
 ```typescript
-@public
+@private
 contract Person {
     id: string;
     name: string;
@@ -176,8 +197,7 @@ contract Person {
 }
 ```
 
-Since the contract has been decorated with the `@public` directive, anyone can not only read `Person` record data, but also invoke the `setName`, `setAge`, and `del` functions to modify the state of a record.
-
+Once the `Person` contract record has been created, no one can read its data (or update it).
 
 ## Delegation
 
@@ -226,7 +246,7 @@ contract User {
 }
 ```
 <Callout type="warning" emoji="⚠️">
-  Since the chain of delegates must end up on a field of type `PublicKey`, the delegation model requires the usage of public keys (unlike using, say, the `@public` directive). This means that the
+  Since the chain of delegates must end up on a field of type `PublicKey`, the delegation model requires the usage of public keys. This means that the
   user must be authenticated before attempting the operation. This is outside the purview of `Polylang`.
 </Callout>
 
@@ -240,16 +260,15 @@ contract User {
 While delegation provides an elegant way of controlling permissions in `Polylang`, for more complicated scenarios, checking permissions using custom code is often the most flexible approach. This can also turn out to 
 be the easiest to understand in many cases. 
 
-The usual way is to mark the contract `@public`, and then provide tighter constraints via custom checks. For example:
+The usual way is provide tighter constraints via custom checks. For example:
 
 ```typescript
-@public
 contract Team {
     id: string
     members: string[]
     publicKey: PublicKey;
 
-    // Anyone can call this function because of @public on the contract
+    // Anyone can call this function because the contract is public by default
     addMember (id: string) {
       // But you must be signing using the correct key
       if (this.publicKey == ctx.publicKey) {
@@ -267,7 +286,7 @@ contract Team {
 }
 ```
 
-In the example above, we have marked the contract as `@public` so that anyone can read the data. However, for the `addMember` function which modifies data, we wish to have tighter constrainsts. As such, we have two checks in 
+In the example above, anyone can read the data since the `contract` is public by default. However, for the `addMember` function which modifies data, we wish to have tighter constrainsts. As such, we have two checks in 
 place - the first check ensures that the public key of the user invoking the function matches the public key stored in the contract during the creation of the record. 
 
 Secondly, we have a custom check that allows the operation to proceed only if we have enough members in the team. This second form of checks cannot be done using directives and/or delegates, and is domain-specific in nature.
@@ -281,11 +300,11 @@ combined to obtain varying granularities of permissions.
 
 | Directive          | Entity     | Read                                             | Write                                             | 
 |:-------------------|:----------:|:------------------------------------------------:|--------------------------------------------------:|
-| None               | Contract | No one                                           | No one                                            |
-| @public            | Contract | Anyone                                           | Anyone                                            |
-| @read              | Contract | Anyone                                           | No one                                            |
+| None / @public     | Contract   | Anyone                                           |Anyone                                             |
+| @private           | Contract   | No one                                           | No one                                            |
+| @read              | Contract   | Anyone                                           | No one                                            |
 | @read              | field      | Only user with matching public key               | No one                                            |
-| @call              | Contract | No one                                           | Anyone                                            |
+| @call              | Contract   | No one                                           | Anyone                                            |
 | @call              | function   | No one                                           | Only user with matching public key                |
 | @delegate + @read  | function   | Only user with a transitively matching public key| No one                                            |
 | @delegate + @call  | function   | No one                                           | Only user with a transitively matching public key |

--- a/site/pages/docs/zk-proofs/polylang-and-zk.mdx
+++ b/site/pages/docs/zk-proofs/polylang-and-zk.mdx
@@ -49,7 +49,6 @@ The use case is that we wish to add two numbers which are supplied to our progra
 Define the contract:
 
 ```typescript
-@public
 contract AddNums {
     sum: number; // this will store the sum
 
@@ -62,7 +61,7 @@ contract AddNums {
 Compile and run the program passing the numbers `1` and `2` as inputs:
 
 ```bash
-$ cargo run --bin compile -- contract:AddNums function:addNums <<< '@public contract AddNums { sum: number; addNums(a: number, b: number) { this.sum = a + b; }}' | \
+$ cargo run --bin compile -- contract:AddNums function:addNums <<< 'contract AddNums { sum: number; addNums(a: number, b: number) { this.sum = a + b; }}' | \
 cargo run -p miden-run -- --this-json '{ "sum": 0 }' \
   --advice-tape-json '[1, 2]'
 ```
@@ -79,7 +78,6 @@ this_json: {"sum":3}
 Consider the contract:
 
 ```typescript
-@public
 contract Person {
     id: string;
     name: string;
@@ -122,7 +120,6 @@ Compile and run the program and pass in 20 for the new `age`:
 ```bash
   $ cargo run --bin compile -- contract:Person function:setAge <<< \
 '
-@public
 contract Person {
     id: string;
     name: string;


### PR DESCRIPTION
Changes:
  - removed `@public` from contracts except from the `permissions` page which describes the new changes.
  - updated the "permissions" page with the changes in default permissions.