### PR TITLE
Fix proof verification

### DIFF
--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -488,6 +488,7 @@ pub struct RunOutput {
     pub cycle_count: u32,
     pub stack: Vec<u64>,
     pub input_stack: Vec<u64>,
+    pub stack_inputs: StackInputs,
 }
 
 impl RunOutput {
@@ -716,6 +717,7 @@ pub fn run<'a>(
             stack: output_stack,
             cycle_count: last_ok_state.clk,
             input_stack: input_stack_values,
+            stack_inputs: input_stack.clone(),
             memory,
         },
         move || {

--- a/wasm-api/example.js
+++ b/wasm-api/example.js
@@ -53,4 +53,6 @@ function report(output, hasThis) {
 const mainOutput = justMain();
 console.log(report(mainOutput, false));
 console.log("Proof is valid?", mainOutput.verify());
-console.log(report(withContracts(), true));
+const contractOutput = withContracts();
+console.log(report(contractOutput, true));
+console.log("Proof is valid?", contractOutput.verify());

--- a/wasm-api/src/lib.rs
+++ b/wasm-api/src/lib.rs
@@ -108,8 +108,7 @@ impl Output {
     pub fn verify(&self) -> Result<bool, JsError> {
         verify(
             self.info.clone(),
-            StackInputs::try_from_values(self.output.input_stack.clone().into_iter())
-                .map_err(|e| JsError::new(&e.to_string()))?,
+            self.output.stack_inputs.clone(),
             self.output_stack.clone().unwrap(),
             miden::ExecutionProof::from_bytes(&self.proof.clone().unwrap().to_vec())
                 .map_err(|err| JsError::new(&format!("failed to parse proof: {}", err)))?,


### PR DESCRIPTION
Previously the added .verify() for withContract proof would fail with:

```
/Users/z0ltan/work/polybase/polylang/wasm-api/pkg/wasm_api.js:293
                throw takeObject(r1);
                ^

Error: constraint evaluations over the out-of-domain frame are inconsistent
    at module.exports.__wbindgen_error_new (/Users/z0ltan/work/polybase/polylang/wasm-api/pkg/wasm_api.js:474:17)
    at wasm://wasm/0116dffa:wasm-function[1550]:0x3a9b23
    at Output.verify (/Users/z0ltan/work/polybase/polylang/wasm-api/pkg/wasm_api.js:288:18)
    at Object.<anonymous> (/Users/z0ltan/work/polybase/polylang/wasm-api/example.js:131:52)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47
```