### PR TITLE
ENG-1237: Update Miden VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,8 +1161,8 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "miden-core",
  "winter-air",
@@ -1164,8 +1170,8 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.6.1"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "miden-core",
  "num_enum",
@@ -1173,8 +1179,8 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.6.1"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "miden-crypto",
  "winter-crypto",
@@ -1184,11 +1190,14 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf95db953ee5fc8ef5a1df2d2e6e55e41587861c793fa26b45a214d3cc0f798"
+checksum = "32dd571edafdd5e8947e4006a905a1c5373f2f8b08b270fea3c998db5be131cf"
 dependencies = [
  "blake3",
+ "cc",
+ "glob",
+ "libc",
  "winter-crypto",
  "winter-math",
  "winter-utils",
@@ -1196,8 +1205,8 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.6.1"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "log",
  "miden-air",
@@ -1207,8 +1216,8 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "elsa",
  "log",
@@ -1232,16 +1241,16 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.6.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "miden-assembly",
 ]
 
 [[package]]
 name = "miden-verifier"
-version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1250,10 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.6.1#3022d257eec9cdeca2273b0b66b633bcb3552274"
+version = "0.7.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?tag=v0.7.0#c097af7ca53da2026cec10d9245a006b42186643"
 dependencies = [
- "log",
  "miden-assembly",
  "miden-processor",
  "miden-prover",
@@ -1318,18 +1326,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,17 @@ name = "compile"
 path = "src/bin/compile/main.rs"
 
 [workspace]
-members = ["parser", "prover", "abi", "miden-run", "error", "tests", "wasm-api", "server", "server-routes"]
+members = [
+    "parser",
+    "prover",
+    "abi",
+    "miden-run",
+    "error",
+    "tests",
+    "wasm-api",
+    "server",
+    "server-routes",
+]
 exclude = ["showcase"]
 
 [features]
@@ -30,13 +40,17 @@ console_error_panic_hook = "0.1.7"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 polylang_parser = { path = "./parser" }
-miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
-miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
-miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
+miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
 winter-math = "*"
 lazy_static = "1.4.0"
 base64 = "0.21.0"
-derive_more = { version = "0.99.17", features = ["deref", "from", "deref_mut"], default-features = false }
+derive_more = { version = "0.99.17", features = [
+    "deref",
+    "from",
+    "deref_mut",
+], default-features = false }
 parking_lot = "0.12.1"
 
 [dev-dependencies]

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -25,6 +25,8 @@ pub enum StdVersion {
     V0_5_0,
     #[serde(rename = "0.6.1")]
     V0_6_1,
+    #[serde(rename = "0.7.0")]
+    V0_7_0,
 }
 
 /// An array of record hashes.

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -15,9 +15,9 @@ abi = { path = "../abi" }
 error = { path = "../error" }
 polylang = { path = "../", default-features = false }
 
-miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
-miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
-miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
-miden-prover = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
+miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
+miden-prover = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
 
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/site/components/pkg/index_bg.js
+++ b/site/components/pkg/index_bg.js
@@ -20,7 +20,11 @@ function takeObject(idx) {
     return ret;
 }
 
-let WASM_VECTOR_LEN = 0;
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
 
 let cachedUint8Memory0 = null;
 
@@ -30,6 +34,22 @@ function getUint8Memory0() {
     }
     return cachedUint8Memory0;
 }
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+}
+
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1);
+    const idx = heap_next;
+    heap_next = heap[idx];
+
+    heap[idx] = obj;
+    return idx;
+}
+
+let WASM_VECTOR_LEN = 0;
 
 const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
 
@@ -97,26 +117,6 @@ function getInt32Memory0() {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
     }
     return cachedInt32Memory0;
-}
-
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
-}
-
-function addHeapObject(obj) {
-    if (heap_next === heap.length) heap.push(heap.length + 1);
-    const idx = heap_next;
-    heap_next = heap[idx];
-
-    heap[idx] = obj;
-    return idx;
 }
 /**
 * @param {string} code
@@ -593,6 +593,11 @@ export function __wbindgen_object_drop_ref(arg0) {
     takeObject(arg0);
 };
 
+export function __wbindgen_string_new(arg0, arg1) {
+    const ret = getStringFromWasm0(arg0, arg1);
+    return addHeapObject(ret);
+};
+
 export function __wbindgen_string_get(arg0, arg1) {
     const obj = getObject(arg1);
     const ret = typeof(obj) === 'string' ? obj : undefined;
@@ -600,11 +605,6 @@ export function __wbindgen_string_get(arg0, arg1) {
     var len1 = WASM_VECTOR_LEN;
     getInt32Memory0()[arg0 / 4 + 1] = len1;
     getInt32Memory0()[arg0 / 4 + 0] = ptr1;
-};
-
-export function __wbindgen_string_new(arg0, arg1) {
-    const ret = getStringFromWasm0(arg0, arg1);
-    return addHeapObject(ret);
 };
 
 export function __wbindgen_is_string(arg0) {

--- a/src/compiler/float32.rs
+++ b/src/compiler/float32.rs
@@ -1794,6 +1794,7 @@ mod tests {
     }
 
     use itertools::Itertools;
+    use miden::ProvingOptions;
     use quickcheck_macros::quickcheck;
     use test_case::test_case;
 
@@ -1855,10 +1856,13 @@ mod tests {
         }
         program.push_str("\nend\n");
 
+        let host = miden::DefaultHost::new(miden::MemAdviceProvider::default());
+
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -2125,10 +2129,12 @@ mod tests {
         }
         program.push_str("\nend\n");
 
+        let host = miden::DefaultHost::new(miden::MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )
         .unwrap();
 

--- a/src/compiler/int32.rs
+++ b/src/compiler/int32.rs
@@ -849,6 +849,8 @@ pub(crate) fn lt(compiler: &mut Compiler, a: &Symbol, b: &Symbol) -> Symbol {
 
 #[cfg(test)]
 mod test {
+    use miden::{DefaultHost, MemAdviceProvider, ProvingOptions};
+
     use super::*;
 
     fn new(compiler: &mut Compiler, value: i32) -> Symbol {
@@ -887,10 +889,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )
         .unwrap();
 
@@ -921,10 +925,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -956,8 +962,16 @@ mod test {
         test!(-1, 1, Ok(0));
         test!(-1, -1, Ok(-2));
 
-        test!(i32::MAX, 1, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(i32::MIN, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(
+            i32::MAX,
+            1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
+        test!(
+            i32::MIN,
+            -1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
     }
 
     fn abs(a: i32) -> Result<i32, miden::ExecutionError> {
@@ -980,10 +994,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1013,7 +1029,7 @@ mod test {
         test!(i32::MIN + 1, Ok(i32::MAX));
         test!(2147483584, Ok(2147483584));
 
-        test!(i32::MIN, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(i32::MIN, Err(miden::ExecutionError::FailedAssertion(_, _)));
     }
 
     fn negate(a: i32) -> Result<i32, miden::ExecutionError> {
@@ -1036,10 +1052,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1069,7 +1087,7 @@ mod test {
         test!(i32::MAX, Ok(_min_add_1));
         test!(i32::MIN + 1, Ok(i32::MAX));
 
-        test!(i32::MIN, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(i32::MIN, Err(miden::ExecutionError::FailedAssertion(_, _)));
     }
 
     fn sub(a: i32, b: i32) -> Result<i32, miden::ExecutionError> {
@@ -1095,10 +1113,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1135,8 +1155,16 @@ mod test {
         test!(i32::MIN, -1, Ok(_min_add_1));
         test!(i32::MIN, i32::MIN, Ok(0));
 
-        test!(i32::MIN, 1, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(i32::MAX, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(
+            i32::MIN,
+            1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
+        test!(
+            i32::MAX,
+            -1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
     }
 
     fn mul(a: i32, b: i32) -> Result<i32, miden::ExecutionError> {
@@ -1162,10 +1190,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1205,30 +1235,42 @@ mod test {
         // TODO: fix this case
         // test!(i32::MIN, 1, Ok(i32::MIN));
 
-        test!(i32::MAX, 2, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(i32::MIN, 2, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(
+            i32::MAX,
+            2,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
+        test!(
+            i32::MIN,
+            2,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
         test!(
             i32::MAX,
             i32::MIN,
-            Err(miden::ExecutionError::FailedAssertion(_))
+            Err(miden::ExecutionError::FailedAssertion(_, _))
         );
         test!(
             i32::MIN,
             i32::MAX,
-            Err(miden::ExecutionError::FailedAssertion(_))
+            Err(miden::ExecutionError::FailedAssertion(_, _))
         );
         test!(
             i32::MIN,
             i32::MIN,
-            Err(miden::ExecutionError::FailedAssertion(_))
+            Err(miden::ExecutionError::FailedAssertion(_, _))
         );
         test!(
             i32::MAX,
             i32::MAX,
-            Err(miden::ExecutionError::FailedAssertion(_))
+            Err(miden::ExecutionError::FailedAssertion(_, _))
         );
         // negating i32::MIN overflows, that would be i32::MAX+1
-        test!(i32::MIN, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(
+            i32::MIN,
+            -1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
     }
 
     fn div(a: i32, b: i32) -> Result<i32, miden::ExecutionError> {
@@ -1254,10 +1296,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1281,9 +1325,13 @@ mod test {
             };
         }
 
-        test!(0, 0, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(1, 0, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(i32::MIN, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(0, 0, Err(miden::ExecutionError::FailedAssertion(_, _)));
+        test!(1, 0, Err(miden::ExecutionError::FailedAssertion(_, _)));
+        test!(
+            i32::MIN,
+            -1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
 
         test!(0, 1, Ok(0));
         test!(1, 1, Ok(1));
@@ -1327,10 +1375,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1354,9 +1404,13 @@ mod test {
             };
         }
 
-        test!(0, 0, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(1, 0, Err(miden::ExecutionError::FailedAssertion(_)));
-        test!(i32::MIN, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(0, 0, Err(miden::ExecutionError::FailedAssertion(_, _)));
+        test!(1, 0, Err(miden::ExecutionError::FailedAssertion(_, _)));
+        test!(
+            i32::MIN,
+            -1,
+            Err(miden::ExecutionError::FailedAssertion(_, _))
+        );
 
         test!(0, 1, Ok(0));
         test!(1, 1, Ok(0));
@@ -1393,10 +1447,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1425,7 +1481,7 @@ mod test {
         test!(i32::MAX, 0, Ok(i32::MAX));
         test!(-1, 0, Ok(-1));
         test!(-2, 1, Ok(-1));
-        test!(-2, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(-2, -1, Err(miden::ExecutionError::FailedAssertion(_, _)));
 
         // TODO: fix this case
         // test!(i32::MIN, 0, Ok(i32::MIN));
@@ -1454,10 +1510,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();
@@ -1486,7 +1544,7 @@ mod test {
         test!(i32::MAX, 0, Ok(i32::MAX));
         test!(-1, 0, Ok(-1));
         test!(-2, 1, Ok(-4));
-        test!(-2, -1, Err(miden::ExecutionError::FailedAssertion(_)));
+        test!(-2, -1, Err(miden::ExecutionError::FailedAssertion(_, _)));
     }
 
     fn gt(a: i32, b: i32) -> Result<bool, miden::ExecutionError> {
@@ -1512,10 +1570,12 @@ mod test {
         }
         program.push_str("\nend\n");
 
+        let host = DefaultHost::new(MemAdviceProvider::default());
         let outputs = miden::execute(
             &miden::Assembler::default().compile(&program).unwrap(),
             miden::StackInputs::default(),
-            miden::MemAdviceProvider::default(),
+            host,
+            ProvingOptions::default().exec_options,
         )?;
 
         let stack = outputs.stack_outputs().stack();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -4185,7 +4185,7 @@ pub fn compile(
             .into_iter()
             .map(|x| x.0)
             .collect(),
-        std_version: Some(StdVersion::V0_6_1),
+        std_version: Some(StdVersion::V0_7_0),
     };
 
     let mut uses_sha256 = false;

--- a/wasm-api/Cargo.toml
+++ b/wasm-api/Cargo.toml
@@ -12,11 +12,10 @@ crate-type = ["cdylib", "rlib"]
 abi = { path = "../abi" }
 polylang-prover = { path = "../prover" }
 polylang = { path = "../" }
-miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", default-features = false }
+miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.7.0", default-features = false }
 error = { path = "../error" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 base64 = "0.21.4"
-

--- a/wasm-api/example.js
+++ b/wasm-api/example.js
@@ -107,6 +107,28 @@ function withCountryCity() {
   return output;
 }
 
+function fibonacci() {
+  let program = pkg.compile(`
+  function main(p: u32, a: u32, b: u32) {
+    for (let i: u32 = 0; i < p; i++) {
+      let c = a.wrappingAdd(b);
+      a = b;
+      b = c;
+    }
+  }`,
+    null,
+    "main"
+  )
+
+  let output = program.run(
+    JSON.stringify(null),
+    JSON.stringify([30, 1, 1]),
+    true
+  );
+
+  return output;
+}
+
 function report(output, hasThis) {
   return {
     proof: output.proof(),
@@ -147,3 +169,7 @@ verifyProof(arraysOutput);
 const countryCityOutput = withCountryCity();
 console.log(report(countryCityOutput, true));
 verifyProof(countryCityOutput);
+
+const fibonacciOutput = fibonacci();
+console.log(report(fibonacciOutput, false));
+verifyProof(fibonacciOutput);

--- a/wasm-api/src/lib.rs
+++ b/wasm-api/src/lib.rs
@@ -233,7 +233,7 @@ pub fn verify(
     miden_verify(
         program_info,
         stack_inputs,
-        output_stack,
+        output_stack.map_err(|e| JsError::new(&e.to_string()))?,
         miden::ExecutionProof::from_bytes(&proof.unwrap())
             .map_err(|err| JsError::new(&format!("failed to parse proof: {}", err)))?,
     )


### PR DESCRIPTION
Changes:
  - updated miden_vm from v0.6.1 to v0.7.0
  - updated ABI to v0_7_0
  - added wasm test for Fibonacci example.
  - updated wasm api and updated wasm pkg in site.
  - checked that the `showcase` examples are working.

Notes:
   - Miden VM v0.7.0 has two main relevant changes:
     * `AdviceProvider` has been subsumed by [Host](https://docs.rs/miden-processor/0.7.0/miden_processor/trait.Host.html), and
     * `ProofOptions` has been replaced by [ProvingOptions](https://docs.rs/miden-prover/latest/miden_prover/struct.ProvingOptions.html)

Miden-VM v0.7.0 Release Notes: https://github.com/0xPolygonMiden/miden-vm/releases/tag/v0.7.0